### PR TITLE
GUIDE-50 회원 기본 정보 백엔드 작업

### DIFF
--- a/run/src/main/java/com/guide/run/global/jwt/JwtProvider.java
+++ b/run/src/main/java/com/guide/run/global/jwt/JwtProvider.java
@@ -67,6 +67,11 @@ public class JwtProvider {
         }
     }
 
+    public String extractUserId(HttpServletRequest httpServletRequest){
+        String accessToken = resolveToken(httpServletRequest);
+        return getSocialId(accessToken);
+    }
+
     public String resolveToken(HttpServletRequest request){
         String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
         if(bearer!=null && bearer.startsWith("Bearer "))

--- a/run/src/main/java/com/guide/run/global/security/user/CustomUserDetailsService.java
+++ b/run/src/main/java/com/guide/run/global/security/user/CustomUserDetailsService.java
@@ -14,7 +14,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
     @Override
     public UserDetails loadUserByUsername(String socialId) throws UsernameNotFoundException {
-        User user = userRepository.findBySocialId(socialId).orElseThrow();
+        User user = userRepository.findById(socialId).orElseThrow();
         return new CustomUserDetails(user);
     }
 }

--- a/run/src/main/java/com/guide/run/user/controller/SignController.java
+++ b/run/src/main/java/com/guide/run/user/controller/SignController.java
@@ -2,70 +2,79 @@ package com.guide.run.user.controller;
 
 import com.guide.run.global.cookie.service.CookieService;
 import com.guide.run.global.jwt.JwtProvider;
+import com.guide.run.user.dto.GuideSignupDto;
+import com.guide.run.user.dto.PermissionDto;
 import com.guide.run.user.dto.ViSignupDto;
-import com.guide.run.user.entity.*;
-import com.guide.run.user.repository.PartnerRepository;
-import com.guide.run.user.repository.UserRepository;
-import com.guide.run.user.response.LoginResponse;
+import com.guide.run.user.dto.response.LoginResponse;
+import com.guide.run.user.dto.response.SignupResponse;
 import com.guide.run.user.profile.OAuthProfile;
-import com.guide.run.user.response.SignupResponse;
+import com.guide.run.user.service.UserInfoService;
 import com.guide.run.user.service.ProviderService;
 import com.guide.run.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 import javax.naming.CommunicationException;
 
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class SignController {
     private final ProviderService providerService;
     private final JwtProvider jwtProvider;
     private final CookieService cookieService;
     private final UserService userService;
 
-    @PostMapping("/api/oauth/login/kakao")
+
+    @PostMapping("/oauth/login/kakao")
     public LoginResponse kakaoLogin(String code, HttpServletResponse response) throws CommunicationException {
         String accessToken = providerService.getAccessToken(code, "kakao").getAccess_token();
         OAuthProfile oAuthProfile = providerService.getProfile(accessToken,"kakao");
-        String socialId = oAuthProfile.getSocialId();
-        String userStatus = userService.getUserStatus(socialId);
+        String userId = oAuthProfile.getSocialId();
+        String userStatus = userService.getUserStatus(userId);
 
         cookieService.createCookie("refreshToken",response);
 
         return LoginResponse.builder()
-                .accessToken(jwtProvider.createAccessToken(socialId))
+                .accessToken(jwtProvider.createAccessToken(userId))
                 .userStatus(userStatus)
                 .build();
     }
 
     @Secured("ROLE_NEW")
-    //정보 입력이 완료되면 임시 토큰이 아닌 accessToken 발급
-    @PostMapping("/api/signup/vi")
-    public SignupResponse viSignup(@RequestBody ViSignupDto viSignupDto, HttpServletRequest httpServletRequest){
-        String accessToken = jwtProvider.resolveToken(httpServletRequest);
-        String socialId = jwtProvider.getSocialId(accessToken);
-        User signedUser = userService.viSignup(socialId, viSignupDto);
-        return SignupResponse.builder() //socialId값 말고 UUID값 생기면 UUID값도 response에 넣어줘야 할 듯 합니다
-                .accessToken(jwtProvider.createAccessToken(signedUser.getSocialId()))
-                .userStatus(Role.VWAIT.getValue())
-                .build();
+    @PostMapping("/signup/vi")
+    public ResponseEntity<SignupResponse> viSignup(@RequestBody ViSignupDto viSignupDto, HttpServletRequest httpServletRequest){
+        String userId = jwtProvider.extractUserId(httpServletRequest);
+        SignupResponse response = userService.viSignup(userId, viSignupDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Secured("ROLE_NEW")
+    @PostMapping("/signup/guide")
+    public ResponseEntity<SignupResponse> guideSignup(@RequestBody GuideSignupDto guideSignupDto, HttpServletRequest httpServletRequest){
+        String userId = jwtProvider.extractUserId(httpServletRequest);
+        SignupResponse response = userService.guideSignup(userId, guideSignupDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
 
-    @PostMapping("/api/oauth/token/google")
+
+
+    @PostMapping("/oauth/token/google")
     public LoginResponse googleSignup(String code,HttpServletResponse response) throws CommunicationException {
         String accessToken = providerService.getAccessToken(code, "google").getAccess_token();
         OAuthProfile oAuthProfile = providerService.getProfile(accessToken,"google");
-        String socialId = oAuthProfile.getSocialId();
+        String userId = oAuthProfile.getSocialId();
 
         return LoginResponse.builder()
-                .accessToken(jwtProvider.createAccessToken(socialId))
+                .accessToken(jwtProvider.createAccessToken(userId))
                 .build();
     }
+
 }

--- a/run/src/main/java/com/guide/run/user/controller/TestController.java
+++ b/run/src/main/java/com/guide/run/user/controller/TestController.java
@@ -1,7 +1,7 @@
 package com.guide.run.user.controller;
 
 
-import com.guide.run.user.entity.Role;
+import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.entity.User;
 import com.guide.run.user.repository.UserRepository;
 
@@ -31,11 +31,11 @@ public class TestController {
     @GetMapping("/user/create")
     public String userCreateTest(){
         User user = User.builder()
-                .socialId("kakao_1")
+                .userId("kakao_1")
                 .role(Role.VADMIN)
                 .build();
         User user2 = User.builder()
-                .socialId("kakao_2")
+                .userId("kakao_2")
                 .role(Role.VWAIT)
                 .build();
         userRepository.save(user);

--- a/run/src/main/java/com/guide/run/user/controller/UserInfoController.java
+++ b/run/src/main/java/com/guide/run/user/controller/UserInfoController.java
@@ -1,0 +1,43 @@
+package com.guide.run.user.controller;
+
+import com.guide.run.global.jwt.JwtProvider;
+import com.guide.run.user.dto.PermissionDto;
+import com.guide.run.user.dto.PersonalInfoDto;
+import com.guide.run.user.service.UserInfoService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserInfoController {
+    private final UserInfoService userInfoService;
+    private final JwtProvider jwtProvider;
+
+    @GetMapping("/mypage/info/permission")
+    public ResponseEntity<PermissionDto> getPermission(HttpServletRequest httpServletRequest){
+        String userId = jwtProvider.extractUserId(httpServletRequest);
+        PermissionDto response = userInfoService.getPermission(userId);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/mypage/info/personal")
+    public ResponseEntity<PersonalInfoDto> getPersonalInfo(HttpServletRequest httpServletRequest){
+        String userId = jwtProvider.extractUserId(httpServletRequest);
+        PersonalInfoDto response = userInfoService.getPersonalInfo(userId);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/mypage/info/personal")
+    public ResponseEntity<PersonalInfoDto> editPersonalInfo(@RequestBody PersonalInfoDto personalInfoDto, HttpServletRequest httpServletRequest){
+        String userId = jwtProvider.extractUserId(httpServletRequest);
+        PersonalInfoDto response = userInfoService.editPersonalInfo(userId, personalInfoDto);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+}

--- a/run/src/main/java/com/guide/run/user/dto/GuideRunningInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/GuideRunningInfoDto.java
@@ -1,0 +1,21 @@
+package com.guide.run.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class GuideRunningInfoDto {
+    private String recordDegree;
+    private String detailRecord;
+    private boolean guideExp;
+    private String viName;
+    private String viRecord;
+    private String viCount; //상세한 가이드 경험
+    private String guidingPace; //가이드 가능한 페이스 그룹
+    private String howToKnow;
+    private String motive;
+    private String hopePrefs;
+}

--- a/run/src/main/java/com/guide/run/user/dto/GuideSignupDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/GuideSignupDto.java
@@ -5,7 +5,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class ViSignupDto {
+public class GuideSignupDto {
     //private String accountId;
     //private String password;
     private String name;
@@ -18,14 +18,18 @@ public class ViSignupDto {
     private String snsId;
     private boolean openSns;
 
-    //vi 전용 정보
-    private boolean runningExp;
-    private String guideName;
+    //가이드 전용 정보
+    private boolean guideExp;
+    private String viName;
+    private String viRecord;
+    private String viCount; //상세한 가이드 경험
+    private String guidingPace; //가이드 가능한 페이스 그룹
 
     //아카이브 데이터
     private String runningPlace;
-    private String howToKnow; //러닝 경험 있을 시 null
-    private String motive; //러닝 경험 있을 시 null
+    private String howToKnow; //가이드 경험 있을 시 null
+    private String motive; //가이더 경험 있을 시 null
+    private String hopePrefs;
 
     //약관동의
     private boolean privacy;

--- a/run/src/main/java/com/guide/run/user/dto/PermissionDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/PermissionDto.java
@@ -1,0 +1,13 @@
+package com.guide.run.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PermissionDto {
+    private boolean privacy;
+    private boolean portraitRights;
+}

--- a/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
@@ -1,0 +1,34 @@
+package com.guide.run.user.dto;
+
+import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.type.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PersonalInfoDto {
+    private String role;
+    private String gender;
+    private String name;
+    private String phoneNumber;
+    private boolean openNumber;
+    private int age;
+    private String snsId;
+    private boolean openSns;
+
+    public static PersonalInfoDto userToInfoDto(User user){
+        return PersonalInfoDto.builder()
+                .role(user.getRole().getValue())
+                .name(user.getName())
+                .gender(user.getGender())
+                .phoneNumber(user.getPhoneNumber())
+                .age(user.getAge())
+                .snsId(user.getSnsId())
+                .openSns(user.isOpenSns())
+                .openNumber(user.isOpenNumber())
+                .build();
+    }
+}

--- a/run/src/main/java/com/guide/run/user/dto/ViRunningInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/ViRunningInfoDto.java
@@ -1,0 +1,17 @@
+package com.guide.run.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ViRunningInfoDto {
+    private String recordDegree;
+    private String detailRecord;
+    private boolean runningExp;
+    private String howToKnow; //러닝 경험 없을 시 null
+    private String motive; //러닝 경험 없을 시 null
+    private String hopePrefs;
+}

--- a/run/src/main/java/com/guide/run/user/dto/request/OAuthRequest.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/OAuthRequest.java
@@ -1,4 +1,4 @@
-package com.guide.run.user.request;
+package com.guide.run.user.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/run/src/main/java/com/guide/run/user/dto/response/LoginResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.guide.run.user.response;
+package com.guide.run.user.dto.response;
 
 
 import lombok.*;

--- a/run/src/main/java/com/guide/run/user/dto/response/OAuthCodeResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/OAuthCodeResponse.java
@@ -1,4 +1,4 @@
-package com.guide.run.user.response;
+package com.guide.run.user.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/run/src/main/java/com/guide/run/user/dto/response/SignupResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/SignupResponse.java
@@ -1,15 +1,13 @@
-package com.guide.run.user.response;
+package com.guide.run.user.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class SignupResponse {
+    private String uuid;
     private String accessToken;
     private String userStatus;
 }

--- a/run/src/main/java/com/guide/run/user/entity/ArchiveData.java
+++ b/run/src/main/java/com/guide/run/user/entity/ArchiveData.java
@@ -1,0 +1,21 @@
+package com.guide.run.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArchiveData {
+    @Id
+    private String userId;
+    private String runningPlace;
+    private String howToKnow;
+    private String motive;
+
+}

--- a/run/src/main/java/com/guide/run/user/entity/Guide.java
+++ b/run/src/main/java/com/guide/run/user/entity/Guide.java
@@ -8,11 +8,13 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @Getter
 @DiscriminatorValue("G")
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
 public class Guide extends User{
     private boolean guideExp;
     private String viName;
+    private String viRecord;
+    private String viCount; //상세한 가이드 경험
+    private String guidingPace; //가이드 가능한 페이스 그룹
 }

--- a/run/src/main/java/com/guide/run/user/entity/Partner.java
+++ b/run/src/main/java/com/guide/run/user/entity/Partner.java
@@ -3,8 +3,9 @@ package com.guide.run.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Getter
+
 @Entity
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -18,6 +19,6 @@ public class Partner {
     @ManyToOne
     @JoinColumn(name = "GUIDE_ID")
     private Guide guideId;
-    private int competitionCnt;
+    private int contestCnt;
     private int trainingCnt;
 }

--- a/run/src/main/java/com/guide/run/user/entity/Permission.java
+++ b/run/src/main/java/com/guide/run/user/entity/Permission.java
@@ -1,0 +1,20 @@
+package com.guide.run.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class Permission {
+    @Id
+    private String userId;
+    private boolean privacy;
+    private boolean portraitRights;
+
+}

--- a/run/src/main/java/com/guide/run/user/entity/SignUpInfo.java
+++ b/run/src/main/java/com/guide/run/user/entity/SignUpInfo.java
@@ -1,0 +1,14 @@
+package com.guide.run.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class SignUpInfo {
+    @Id
+    private String userId;
+    @Column(unique = true)
+    private String accountId;
+    private String password;
+}

--- a/run/src/main/java/com/guide/run/user/entity/User.java
+++ b/run/src/main/java/com/guide/run/user/entity/User.java
@@ -2,27 +2,34 @@ package com.guide.run.user.entity;
 
 
 import com.guide.run.global.entity.BaseEntity;
+import com.guide.run.user.entity.type.Role;
 import jakarta.persistence.*;
-import jdk.jfr.Name;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import java.util.List;
+import java.time.LocalDateTime;
 
-@Getter
+
 @Entity
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn
 @SuperBuilder
 public class User extends BaseEntity {
+    @Column(unique = true, nullable = false)
+    private String uuid;
+
     @Id
-    @Column(name = "social_id")
-    private String socialId;
+    private String userId;
+
     private String name;
     private String gender;
     private String phoneNumber;
+    private boolean openNumber;
     private int age;
     private String detailRecord;
     private String recordDegree; //개인 기록
@@ -30,4 +37,22 @@ public class User extends BaseEntity {
     private Role role;
     //private List<Event> eventLists;
     private String snsId;
+    private boolean openSns;
+
+    public void editUser(String name,
+                         String gender,
+                         String phoneNumber,
+                         boolean openNumber,
+                         int age,
+                         String snsId,
+                         boolean openSns) {
+        this.name = name;
+        this.gender = gender;
+        this.phoneNumber = phoneNumber;
+        this.openNumber = openNumber;
+        this.age = age;
+        this.snsId = snsId;
+        this.openSns = openSns;
+    }
 }
+

--- a/run/src/main/java/com/guide/run/user/entity/User.java
+++ b/run/src/main/java/com/guide/run/user/entity/User.java
@@ -4,6 +4,7 @@ package com.guide.run.user.entity;
 import com.guide.run.global.entity.BaseEntity;
 import com.guide.run.user.entity.type.Role;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/run/src/main/java/com/guide/run/user/entity/Vi.java
+++ b/run/src/main/java/com/guide/run/user/entity/Vi.java
@@ -6,9 +6,8 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Data
+@Getter
 @DiscriminatorValue("V")
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder

--- a/run/src/main/java/com/guide/run/user/entity/type/Role.java
+++ b/run/src/main/java/com/guide/run/user/entity/type/Role.java
@@ -1,4 +1,4 @@
-package com.guide.run.user.entity;
+package com.guide.run.user.entity.type;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/run/src/main/java/com/guide/run/user/factory/OAuthRequestFactory.java
+++ b/run/src/main/java/com/guide/run/user/factory/OAuthRequestFactory.java
@@ -1,6 +1,6 @@
 package com.guide.run.user.factory;
 
-import com.guide.run.user.request.OAuthRequest;
+import com.guide.run.user.dto.request.OAuthRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/run/src/main/java/com/guide/run/user/repository/ArchiveDataRepository.java
+++ b/run/src/main/java/com/guide/run/user/repository/ArchiveDataRepository.java
@@ -1,0 +1,7 @@
+package com.guide.run.user.repository;
+
+import com.guide.run.user.entity.ArchiveData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArchiveDataRepository extends JpaRepository<ArchiveData, String> {
+}

--- a/run/src/main/java/com/guide/run/user/repository/PermissionRepository.java
+++ b/run/src/main/java/com/guide/run/user/repository/PermissionRepository.java
@@ -1,0 +1,7 @@
+package com.guide.run.user.repository;
+
+import com.guide.run.user.entity.Permission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PermissionRepository extends JpaRepository<Permission, String> {
+}

--- a/run/src/main/java/com/guide/run/user/repository/UserRepository.java
+++ b/run/src/main/java/com/guide/run/user/repository/UserRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,String> {
-    Optional<User> findBySocialId(String socialId);
 }
 

--- a/run/src/main/java/com/guide/run/user/service/ProviderService.java
+++ b/run/src/main/java/com/guide/run/user/service/ProviderService.java
@@ -1,11 +1,9 @@
 package com.guide.run.user.service;
 
 import com.google.gson.Gson;
-import com.guide.run.user.request.OAuthRequest;
-import com.guide.run.user.response.OAuthCodeResponse;
+import com.guide.run.user.dto.request.OAuthRequest;
+import com.guide.run.user.dto.response.OAuthCodeResponse;
 import com.guide.run.user.factory.OAuthRequestFactory;
-import com.guide.run.user.entity.Role;
-import com.guide.run.user.entity.User;
 import com.guide.run.user.info.GetGoogleInfo;
 import com.guide.run.user.info.GetKakaoInfo;
 import com.guide.run.user.profile.*;
@@ -14,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;

--- a/run/src/main/java/com/guide/run/user/service/UserInfoService.java
+++ b/run/src/main/java/com/guide/run/user/service/UserInfoService.java
@@ -1,0 +1,89 @@
+package com.guide.run.user.service;
+
+import com.guide.run.user.dto.PermissionDto;
+import com.guide.run.user.dto.PersonalInfoDto;
+import com.guide.run.user.dto.ViRunningInfoDto;
+import com.guide.run.user.entity.Permission;
+import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.Vi;
+import com.guide.run.user.repository.ArchiveDataRepository;
+import com.guide.run.user.repository.PermissionRepository;
+import com.guide.run.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class UserInfoService {
+    private final UserRepository userRepository;
+    private final PermissionRepository permissionRepository;
+    private final ArchiveDataRepository archiveDataRepository;
+
+    public PermissionDto getPermission(String userId){
+        Permission permission = permissionRepository.findById(userId).orElseThrow(
+                () -> new NoSuchElementException("유저 정보를 찾을 수 없습니다.")
+        );
+
+        PermissionDto response = PermissionDto.builder()
+                .privacy(permission.isPrivacy())
+                .portraitRights(permission.isPortraitRights())
+                .build();
+
+        return response;
+    }
+
+    //todo : 러닝 스펙 조회, 수정은 따로 공부가 필요할 듯 하다..
+    //러닝 스펙 조회
+    //러닝 스펙 수정
+
+    //개인 정보 조회
+    public PersonalInfoDto getPersonalInfo(String userId){
+        //역할, 성별, 이름, 전화번호, 나이, sns
+
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new NoSuchElementException("유저 정보를 찾을 수 없습니다.")
+        );
+
+        PersonalInfoDto response = PersonalInfoDto.builder()
+                .role(user.getRole().getValue())
+                .name(user.getName())
+                .gender(user.getGender())
+                .phoneNumber(user.getPhoneNumber())
+                .openNumber(user.isOpenNumber())
+                .age(user.getAge())
+                .snsId(user.getSnsId())
+                .openSns(user.isOpenSns())
+                .build();
+
+        return response;
+    }
+    //개인 정보 수정
+    @Transactional
+    public PersonalInfoDto editPersonalInfo(String userId, PersonalInfoDto dto){
+        //성별, 이름, 전화번호, 나이, sns
+
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new NoSuchElementException("유저 정보를 찾을 수 없습니다.")
+        );
+
+        user.editUser(
+                dto.getName(),
+                dto.getGender(),
+                dto.getPhoneNumber(),
+                dto.isOpenNumber(),
+                dto.getAge(),
+                dto.getSnsId(),
+                dto.isOpenSns()
+        );
+
+        PersonalInfoDto response = PersonalInfoDto.userToInfoDto(user);
+
+        return response;
+    }
+}

--- a/run/src/main/java/com/guide/run/user/service/UserService.java
+++ b/run/src/main/java/com/guide/run/user/service/UserService.java
@@ -1,14 +1,20 @@
 package com.guide.run.user.service;
 
+import com.guide.run.global.jwt.JwtProvider;
+import com.guide.run.user.dto.GuideSignupDto;
 import com.guide.run.user.dto.ViSignupDto;
-import com.guide.run.user.entity.Role;
-import com.guide.run.user.entity.User;
-import com.guide.run.user.entity.Vi;
+import com.guide.run.user.dto.response.SignupResponse;
+import com.guide.run.user.entity.*;
+import com.guide.run.user.entity.type.Role;
+import com.guide.run.user.repository.ArchiveDataRepository;
+import com.guide.run.user.repository.PermissionRepository;
 import com.guide.run.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 
 @RequiredArgsConstructor
@@ -16,59 +22,159 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class UserService {
     private final UserRepository userRepository;
+    private final ArchiveDataRepository archiveDataRepository;
+    private final PermissionRepository permissionRepository;
+    private final JwtProvider jwtProvider;
 
-    //WAIT 정보를 입력까지 마치고 가입 승인전인 사용자
-    //NEW 소셜 인증만 한 새로운 사용자
-    //EXIST 기가입자
-    public String getUserStatus(String socialId){
-        String reAssignSocialId = reAssignSocialId(socialId);
-        User user = userRepository.findBySocialId(reAssignSocialId).orElse(null);
+    public String getUserStatus(String userId){
+        String reAssignSocialId = reAssignSocialId(userId);
+        User user = userRepository.findById(userId).orElse(null);
         if(user != null){
-            return user.getRole().getValue();
-        }
-        else{
+                return user.getRole().getValue();
+        }else{
             //신규 가입자의 경우 인증을 위해 임시 유저 생성
             //가입이 완료되면 새 토큰 다시 줘야함
             userRepository.save(User.builder()
-                    .socialId(socialId)
+                    .userId(userId)
                     .role(Role.NEW)
+                    .uuid(getUUID())
                     .build());
             return Role.NEW.getValue();
         }
     }
 
     @Transactional
-    public User viSignup(String socialId, ViSignupDto viSignupDto){
-        User user = userRepository.findBySocialId(reAssignSocialId(socialId)).orElse(null);
+    public SignupResponse viSignup(String userId, ViSignupDto viSignupDto){
+        User user = userRepository.findById(reAssignSocialId(userId)).orElse(null);
         if(user!=null) {
             log.info("에러발생");
-            return user; //기가입자나 이미 정보를 입력한 회원이 재요청한 경우 이므로 에러 코드 추가
-        }else{
-            User vi = Vi.builder()
+            return null; //기가입자나 이미 정보를 입력한 회원이 재요청한 경우 이므로 에러 코드 추가
+        } else {
+            Vi vi = Vi.builder()
                     .runningExp(viSignupDto.isRunningExp())
                     .guideName(viSignupDto.getGuideName())
-                    .socialId(reAssignSocialId(socialId))
+                    .uuid(getUUID())
+                    .userId(userId)
                     .name(viSignupDto.getName())
                     .gender(viSignupDto.getGender())
                     .phoneNumber(viSignupDto.getPhoneNumber())
+                    .openNumber(viSignupDto.isOpenNumber())
                     .age(viSignupDto.getAge())
                     .detailRecord(viSignupDto.getDetailRecord())
                     .recordDegree(viSignupDto.getRecordDegree())
                     .role(Role.VWAIT)
                     .snsId(viSignupDto.getSnsId())
+                    .openSns(viSignupDto.isOpenSns())
                     .build();
-            userRepository.delete(userRepository.findBySocialId(socialId).orElse(null)); //임시 유저 삭제
-            return  userRepository.save(vi);
+
+            userRepository.delete(userRepository.findById(userId).orElse(null)); //임시 유저 삭제
+
+            Vi newVi = userRepository.save(vi);
+
+            ArchiveData archiveData = ArchiveData.builder()
+                    .userId(userId)
+                    .howToKnow(viSignupDto.getHowToKnow())
+                    .motive(viSignupDto.getMotive())
+                    .runningPlace(viSignupDto.getRunningPlace())
+                    .build();
+
+            archiveDataRepository.save(archiveData); //안 쓰는 데이터 저장
+
+            Permission permission = Permission.builder()
+                    .userId(userId)
+                    .privacy(viSignupDto.isPrivacy())
+                    .portraitRights(viSignupDto.isPortraitRights())
+                    .build();
+
+            permissionRepository.save(permission); //약관 동의 저장
+
+            SignupResponse response = SignupResponse
+                    .builder()
+                    .accessToken(jwtProvider.createAccessToken(userId))
+                    .uuid(newVi.getUuid())
+                    .userStatus(newVi.getRole().getValue())
+                    .build();
+
+            return response;
         }
     }
 
-    //socialId 재할당
+    @Transactional
+    public SignupResponse guideSignup(String userId, GuideSignupDto guideSignupDto){
+        User user = userRepository.findById(reAssignSocialId(userId)).orElse(null);
+        if(user!=null) {
+            log.info("에러발생");
+            return null;
+        } else {
+            Guide guide = Guide.builder()
+                    .uuid(getUUID())
+                    .userId(userId)
+                    .name(guideSignupDto.getName())
+                    .gender(guideSignupDto.getGender())
+                    .phoneNumber(guideSignupDto.getPhoneNumber())
+                    .openNumber(guideSignupDto.isOpenNumber())
+                    .age(guideSignupDto.getAge())
+                    .detailRecord(guideSignupDto.getDetailRecord())
+                    .recordDegree(guideSignupDto.getRecordDegree())
+                    .snsId(guideSignupDto.getSnsId())
+                    .openSns(guideSignupDto.isOpenSns())
+                    .guideExp(guideSignupDto.isGuideExp())
+                    .viName(guideSignupDto.getViName())
+                    .viCount(guideSignupDto.getViCount())
+                    .viRecord(guideSignupDto.getViRecord())
+                    .role(Role.GWAIT)
+                    .build();
+
+
+            userRepository.delete(userRepository.findById(userId).orElse(null)); //임시 유저 삭제
+
+            Guide newGuide = userRepository.save(guide);
+
+
+            ArchiveData archiveData = ArchiveData.builder()
+                    .userId(userId)
+                    .howToKnow(guideSignupDto.getHowToKnow())
+                    .motive(guideSignupDto.getMotive())
+                    .runningPlace(guideSignupDto.getRunningPlace())
+                    .build();
+
+            archiveDataRepository.save(archiveData); //안 쓰는 데이터 저장
+
+
+            Permission permission = Permission.builder()
+                    .userId(userId)
+                    .privacy(guideSignupDto.isPrivacy())
+                    .portraitRights(guideSignupDto.isPortraitRights())
+                    .build();
+
+            permissionRepository.save(permission); //약관 동의 저장
+
+            //todo : 추후 일반 로그인을 위한 SignupInfo도 생성해야 함.
+
+            SignupResponse response = SignupResponse.builder()
+                    .uuid(newGuide.getUuid())
+                    .accessToken(jwtProvider.createAccessToken(userId))
+                    .userStatus(newGuide.getRole().getValue())
+                    .build();
+
+            return response;
+        }
+    }
+
+
+    public String getUUID(){
+        String id = UUID.randomUUID().toString();
+        return id;
+    }
+
+
+    //socialId = userId 재할당
     //기가입자 및 이미 정보를 입력한 회원은 재할당 하지 않음
-    public String reAssignSocialId(String socialId){
-        if(socialId.startsWith("kakao_")){
-            return socialId;
-        }else if(socialId.startsWith("kakao")){
-            return "kakao_"+socialId.substring(6);
+    private String reAssignSocialId(String userId) {
+        if(userId.startsWith("kakao_")){
+            return userId;
+        }else if(userId.startsWith("kakao")){
+            return "kakao_"+userId.substring(6);
         }
         else{
             return "Error";
@@ -78,9 +184,10 @@ public class UserService {
     //임시 자격 부여
     public void temporaryUserCreate(String socialId){
         User user = User.builder()
-                .socialId(socialId)
+                .userId(socialId)
                 .role(Role.NEW)
                 .build();
         userRepository.save(user);
     }
+
 }

--- a/run/src/test/java/com/guide/run/user/service/UserServiceTest.java
+++ b/run/src/test/java/com/guide/run/user/service/UserServiceTest.java
@@ -1,6 +1,6 @@
 package com.guide.run.user.service;
 
-import com.guide.run.user.entity.Role;
+import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.entity.User;
 
 import com.guide.run.user.entity.Vi;
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.UUID;
 
 @SpringBootTest
 class UserServiceTest {
@@ -28,7 +30,8 @@ class UserServiceTest {
     @Test
     void existUserLoginResponse(){
         User user = User.builder()
-                .socialId("kakao_1")
+                .uuid(userService.getUUID())
+                .userId("kakao_1")
                 .role(Role.VI)
                 .build();
         userRepository.save(user);
@@ -40,7 +43,8 @@ class UserServiceTest {
     @Test
     void waitUserLoginResponse(){
         User user = User.builder()
-                .socialId("kakao_1")
+                .uuid(userService.getUUID())
+                .userId("kakao_1")
                 .role(Role.VWAIT)
                 .build();
         userRepository.save(user);
@@ -58,10 +62,12 @@ class UserServiceTest {
     @DisplayName("vi 회원가입")
     @Test
     void viSignup(){
+        String id = UUID.randomUUID().toString();
         Vi vi = Vi.builder()
                 .runningExp(true)
                 .guideName("ljg")
-                .socialId("kakao_1")
+                .uuid(id)
+                .userId("kakao_1")
                 .name("lj")
                 .gender("male")
                 .phoneNumber("010-9999-xxxx")
@@ -71,6 +77,11 @@ class UserServiceTest {
                 .role(Role.VWAIT)
                 .snsId("XXXXX12345")
                 .build();
-        Assertions.assertThat(vi).isEqualTo(userRepository.save(vi));
+
+        Vi newVi = userRepository.save(vi);
+        Assertions.assertThat(vi.getUuid()).isEqualTo(newVi.getUuid());
+        //Assertions.assertThat(vi).isEqualTo(newVi); //created_at 과 updated_at 때문에 같을 수가 없다.
     }
+    
+
 }


### PR DESCRIPTION
- vi와 guide 기본 정보 입력 후 회원가입 구현했습니다.
- socialId 는 userId로 변경했습니다. 앞으로 사용하실 때 socialId 변수명 말고 userId로 사용해주세요
- dto와 entity 각 필드별로 검증하는 코드(Not null 등)는 넣지 않았습니다. 포스트맨으로 테스트할 때 번거로워서 안 넣었지만 추후에 꼭 넣어야 합니다..
- howToKnow는 받아올 때 문자열 배열로 들어와서 이에 맞게 처리하는 로직을 구현해야 합니다. 당장은 string으로 처리했습니다.
- 개인 인적사항 수정과 조회, 약관 동의 조회 까지는 구현하였으나 러닝 스펙은 구현하지 못했습니다. 상속 관계에 있는 entity를 조회하고 수정하는 게 보통 엔티티랑 다른 방식으로 해야 하는 것 같더라고요
- 테스트 코드도 추가해야 합니다... 일단 postman으로 돌렸을 때는 이상없이 작동했습니다.
- pk는 userId로 수정하였고, 자동 증가 id 대신 uuid 를 추가했습니다.
- accessToken에서 userId를 추출하는 코드를 메소드로 만들어서 jwtProvider에 두었습니다. 
- controller와 service가 entity를 교환하는 게 좋지 않다고 생각해서 dto를 교환하도록 코드 작성했습니다.
- SignController와 SignService에 코드를 추가하면 너무 길어질 것 같아서 UserInfo 이름으로 controller service 추가하여 구현했습니다.