### PR TITLE
GUIDE-83 전화번호 패턴 적용 및 숫자만 저장되도록 변경

### DIFF
--- a/run/build.gradle
+++ b/run/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.google.code.gson:gson:2.10.1' // json -> 객체 변환
 	implementation 'javax.xml.bind:jaxb-api:2.3.0'  // base64 encoding시 필요
 	// 참고 https://www.inflearn.com/questions/327430/jaxb-%EC%A7%88%EB%AC%B8%EC%9D%B4-%EC%9E%88%EC%8A%B5%EB%8B%88%EB%8B%A4

--- a/run/src/main/java/com/guide/run/user/controller/SignController.java
+++ b/run/src/main/java/com/guide/run/user/controller/SignController.java
@@ -13,6 +13,7 @@ import com.guide.run.user.service.UserService;
 import com.guide.run.user.service.ViService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -53,7 +54,7 @@ public class SignController {
 
 
     @PostMapping("/signup/vi")
-    public ResponseEntity<SignupResponse> viSignup(@RequestBody ViSignupDto viSignupDto, HttpServletRequest httpServletRequest){
+    public ResponseEntity<SignupResponse> viSignup(@RequestBody @Valid ViSignupDto viSignupDto, HttpServletRequest httpServletRequest){
         String userId = jwtProvider.extractUserId(httpServletRequest);
         SignupResponse response = viService.viSignup(userId, viSignupDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -61,7 +62,7 @@ public class SignController {
 
 
     @PostMapping("/signup/guide")
-    public ResponseEntity<SignupResponse> guideSignup(@RequestBody GuideSignupDto guideSignupDto, HttpServletRequest httpServletRequest){
+    public ResponseEntity<SignupResponse> guideSignup(@RequestBody @Valid GuideSignupDto guideSignupDto, HttpServletRequest httpServletRequest){
         String userId = jwtProvider.extractUserId(httpServletRequest);
         SignupResponse response = guideService.guideSignup(userId, guideSignupDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/run/src/main/java/com/guide/run/user/controller/SignController.java
+++ b/run/src/main/java/com/guide/run/user/controller/SignController.java
@@ -7,8 +7,10 @@ import com.guide.run.user.dto.ViSignupDto;
 import com.guide.run.user.dto.response.LoginResponse;
 import com.guide.run.user.dto.response.SignupResponse;
 import com.guide.run.user.profile.OAuthProfile;
+import com.guide.run.user.service.GuideService;
 import com.guide.run.user.service.ProviderService;
 import com.guide.run.user.service.UserService;
+import com.guide.run.user.service.ViService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,9 @@ public class SignController {
     private final CookieService cookieService;
     private final UserService userService;
 
+    private final ViService viService;
+    private final GuideService guideService;
+
 
     @PostMapping("/oauth/login/kakao")
     public LoginResponse kakaoLogin(String code, HttpServletResponse response) throws CommunicationException {
@@ -50,7 +55,7 @@ public class SignController {
     @PostMapping("/signup/vi")
     public ResponseEntity<SignupResponse> viSignup(@RequestBody ViSignupDto viSignupDto, HttpServletRequest httpServletRequest){
         String userId = jwtProvider.extractUserId(httpServletRequest);
-        SignupResponse response = userService.viSignup(userId, viSignupDto);
+        SignupResponse response = viService.viSignup(userId, viSignupDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -58,11 +63,9 @@ public class SignController {
     @PostMapping("/signup/guide")
     public ResponseEntity<SignupResponse> guideSignup(@RequestBody GuideSignupDto guideSignupDto, HttpServletRequest httpServletRequest){
         String userId = jwtProvider.extractUserId(httpServletRequest);
-        SignupResponse response = userService.guideSignup(userId, guideSignupDto);
+        SignupResponse response = guideService.guideSignup(userId, guideSignupDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
-
 
 
     @PostMapping("/oauth/token/google")

--- a/run/src/main/java/com/guide/run/user/dto/GuideSignupDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/GuideSignupDto.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,8 @@ public class GuideSignupDto {
     //private String password;
     private String name;
     private String gender;
+    @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\s|-)?(?:\\d{3}|\\d{4})?(?:\\s|-)?\\d{4}$",
+            message = "전화번호 형식이 올바르지 않습니다") //todo : 전화번호 형식 관련 에러코드 추가해야 함.
     private String phoneNumber;
     private boolean openNumber;
     private int age;

--- a/run/src/main/java/com/guide/run/user/dto/ViSignupDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/ViSignupDto.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,8 @@ public class ViSignupDto {
     //private String password;
     private String name;
     private String gender;
+    @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\s|-)?(?:\\d{3}|\\d{4})?(?:\\s|-)?\\d{4}$",
+            message = "전화번호 형식 에러") //todo : 전화번호 형식 관련 에러코드 추가해야 함.
     private String phoneNumber;
     private boolean openNumber;
     private int age;

--- a/run/src/main/java/com/guide/run/user/service/GuideService.java
+++ b/run/src/main/java/com/guide/run/user/service/GuideService.java
@@ -30,16 +30,16 @@ public class GuideService {
     public SignupResponse guideSignup(String privateId, GuideSignupDto guideSignupDto){
         User user = userRepository.findById(userService.reAssignReturn(privateId)).orElse(null);
         if(user!=null) {
-            log.info("에러발생");
+            log.info("에러발생"); //todo : 에러코드 추가해야 합니다.
             return null;
         } else {
-
+            String phoneNum = userService.extractNumber(guideSignupDto.getPhoneNumber());
             User guide = User.builder()
                     .userId(userService.getUUID())
                     .privateId(privateId)
                     .name(guideSignupDto.getName())
                     .gender(guideSignupDto.getGender())
-                    .phoneNumber(guideSignupDto.getPhoneNumber())
+                    .phoneNumber(phoneNum)
                     .openNumber(guideSignupDto.isOpenNumber())
                     .age(guideSignupDto.getAge())
                     .detailRecord(guideSignupDto.getDetailRecord())
@@ -60,6 +60,7 @@ public class GuideService {
 
 
             userRepository.delete(userRepository.findById(privateId).orElse(null)); //임시 유저 삭제
+            //todo : 에러코드 추가해야 합니다.
 
             User newUser = userRepository.save(guide);
             guideRepository.save(guideInfo);

--- a/run/src/main/java/com/guide/run/user/service/GuideService.java
+++ b/run/src/main/java/com/guide/run/user/service/GuideService.java
@@ -1,0 +1,97 @@
+package com.guide.run.user.service;
+
+import com.guide.run.global.jwt.JwtProvider;
+import com.guide.run.user.dto.GuideSignupDto;
+import com.guide.run.user.dto.response.SignupResponse;
+import com.guide.run.user.entity.ArchiveData;
+import com.guide.run.user.entity.Guide;
+import com.guide.run.user.entity.Permission;
+import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.type.Role;
+import com.guide.run.user.entity.type.UserType;
+import com.guide.run.user.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class GuideService {
+    private final GuideRepository guideRepository;
+    private final UserRepository userRepository;
+    private final ArchiveDataRepository archiveDataRepository;
+    private final PermissionRepository permissionRepository;
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
+
+    @Transactional
+    public SignupResponse guideSignup(String privateId, GuideSignupDto guideSignupDto){
+        User user = userRepository.findById(userService.reAssignReturn(privateId)).orElse(null);
+        if(user!=null) {
+            log.info("에러발생");
+            return null;
+        } else {
+
+            User guide = User.builder()
+                    .userId(userService.getUUID())
+                    .privateId(privateId)
+                    .name(guideSignupDto.getName())
+                    .gender(guideSignupDto.getGender())
+                    .phoneNumber(guideSignupDto.getPhoneNumber())
+                    .openNumber(guideSignupDto.isOpenNumber())
+                    .age(guideSignupDto.getAge())
+                    .detailRecord(guideSignupDto.getDetailRecord())
+                    .recordDegree(guideSignupDto.getRecordDegree())
+                    .snsId(guideSignupDto.getSnsId())
+                    .openSns(guideSignupDto.isOpenSns())
+                    .role(Role.WAIT)
+                    .type(UserType.GUIDE)
+                    .build();
+
+            Guide guideInfo = Guide.builder()
+                    .privateId(privateId)
+                    .guideExp(guideSignupDto.isGuideExp())
+                    .viName(guideSignupDto.getViName())
+                    .viCount(guideSignupDto.getViCount())
+                    .viRecord(guideSignupDto.getViRecord())
+                    .build();
+
+
+            userRepository.delete(userRepository.findById(privateId).orElse(null)); //임시 유저 삭제
+
+            User newUser = userRepository.save(guide);
+            guideRepository.save(guideInfo);
+
+
+            ArchiveData archiveData = ArchiveData.builder()
+                    .privateId(privateId)
+                    .howToKnow(guideSignupDto.getHowToKnow())
+                    .motive(guideSignupDto.getMotive())
+                    .runningPlace(guideSignupDto.getRunningPlace())
+                    .build();
+
+            archiveDataRepository.save(archiveData); //안 쓰는 데이터 저장
+
+
+            Permission permission = Permission.builder()
+                    .privateId(privateId)
+                    .privacy(guideSignupDto.isPrivacy())
+                    .portraitRights(guideSignupDto.isPortraitRights())
+                    .build();
+
+            permissionRepository.save(permission); //약관 동의 저장
+
+            //todo : 추후 일반 로그인을 위한 SignupInfo도 생성해야 함.
+
+            SignupResponse response = SignupResponse.builder()
+                    .uuid(newUser.getUserId())
+                    .accessToken(jwtProvider.createAccessToken(privateId))
+                    .userStatus(newUser.getRole().getValue())
+                    .build();
+
+            return response;
+        }
+    }
+}

--- a/run/src/main/java/com/guide/run/user/service/UserService.java
+++ b/run/src/main/java/com/guide/run/user/service/UserService.java
@@ -45,136 +45,9 @@ public class UserService {
         }
     }
 
-    @Transactional
-    public SignupResponse viSignup(String privateId, ViSignupDto viSignupDto){
-        User user = userRepository.findById(reAssignSocialId(privateId)).orElse(null);
-        if(user!=null) {
-            log.info("에러발생");
-            return null; //기가입자나 이미 정보를 입력한 회원이 재요청한 경우 이므로 에러 코드 추가
-        } else {
-            User vi = User.builder()
-                    .userId(getUUID())
-                    .privateId(privateId)
-                    .name(viSignupDto.getName())
-                    .gender(viSignupDto.getGender())
-                    .phoneNumber(viSignupDto.getPhoneNumber())
-                    .openNumber(viSignupDto.isOpenNumber())
-                    .age(viSignupDto.getAge())
-                    .detailRecord(viSignupDto.getDetailRecord())
-                    .recordDegree(viSignupDto.getRecordDegree())
-                    .role(Role.WAIT)
-                    .type(UserType.VI)
-                    .snsId(viSignupDto.getSnsId())
-                    .openSns(viSignupDto.isOpenSns())
-                    .build();
-
-            Vi viInfo = Vi.builder()
-                    .privateId(privateId)
-                    .runningExp(viSignupDto.isRunningExp())
-                    .guideName(viSignupDto.getGuideName())
-                    .build();
-
-            userRepository.delete(userRepository.findById(privateId).orElse(null)); //임시 유저 삭제
-
-            User newVi = userRepository.save(vi);
-            viRepository.save(viInfo);
-
-            ArchiveData archiveData = ArchiveData.builder()
-                    .privateId(privateId)
-                    .howToKnow(viSignupDto.getHowToKnow())
-                    .motive(viSignupDto.getMotive())
-                    .runningPlace(viSignupDto.getRunningPlace())
-                    .build();
-
-            archiveDataRepository.save(archiveData); //안 쓰는 데이터 저장
-
-            Permission permission = Permission.builder()
-                    .privateId(privateId)
-                    .privacy(viSignupDto.isPrivacy())
-                    .portraitRights(viSignupDto.isPortraitRights())
-                    .build();
-
-            permissionRepository.save(permission); //약관 동의 저장
-
-            SignupResponse response = SignupResponse
-                    .builder()
-                    .accessToken(jwtProvider.createAccessToken(privateId))
-                    .uuid(newVi.getUserId())
-                    .userStatus(newVi.getRole().getValue())
-                    .build();
-
-            return response;
-        }
-    }
-
-    @Transactional
-    public SignupResponse guideSignup(String privateId, GuideSignupDto guideSignupDto){
-        User user = userRepository.findById(reAssignSocialId(privateId)).orElse(null);
-        if(user!=null) {
-            log.info("에러발생");
-            return null;
-        } else {
-
-            User guide = User.builder()
-                    .userId(getUUID())
-                    .privateId(privateId)
-                    .name(guideSignupDto.getName())
-                    .gender(guideSignupDto.getGender())
-                    .phoneNumber(guideSignupDto.getPhoneNumber())
-                    .openNumber(guideSignupDto.isOpenNumber())
-                    .age(guideSignupDto.getAge())
-                    .detailRecord(guideSignupDto.getDetailRecord())
-                    .recordDegree(guideSignupDto.getRecordDegree())
-                    .snsId(guideSignupDto.getSnsId())
-                    .openSns(guideSignupDto.isOpenSns())
-                    .role(Role.WAIT)
-                    .type(UserType.GUIDE)
-                    .build();
-
-            Guide guideInfo = Guide.builder()
-                    .privateId(privateId)
-                    .guideExp(guideSignupDto.isGuideExp())
-                    .viName(guideSignupDto.getViName())
-                    .viCount(guideSignupDto.getViCount())
-                    .viRecord(guideSignupDto.getViRecord())
-                    .build();
 
 
-            userRepository.delete(userRepository.findById(privateId).orElse(null)); //임시 유저 삭제
 
-            User newUser = userRepository.save(guide);
-            guideRepository.save(guideInfo);
-
-
-            ArchiveData archiveData = ArchiveData.builder()
-                    .privateId(privateId)
-                    .howToKnow(guideSignupDto.getHowToKnow())
-                    .motive(guideSignupDto.getMotive())
-                    .runningPlace(guideSignupDto.getRunningPlace())
-                    .build();
-
-            archiveDataRepository.save(archiveData); //안 쓰는 데이터 저장
-
-
-            Permission permission = Permission.builder()
-                    .privateId(privateId)
-                    .privacy(guideSignupDto.isPrivacy())
-                    .portraitRights(guideSignupDto.isPortraitRights())
-                    .build();
-
-            permissionRepository.save(permission); //약관 동의 저장
-
-            //todo : 추후 일반 로그인을 위한 SignupInfo도 생성해야 함.
-
-            SignupResponse response = SignupResponse.builder()
-                    .uuid(newUser.getUserId())
-                    .accessToken(jwtProvider.createAccessToken(privateId))
-                    .userStatus(newUser.getRole().getValue())
-                    .build();
-
-            return response;
-        }
-    }
 
 
     public String getUUID(){
@@ -194,6 +67,10 @@ public class UserService {
         else{
             return "Error";
         }
+    }
+
+    public String reAssignReturn(String privateId){
+        return reAssignSocialId(privateId);
     }
 
     //임시 자격 부여

--- a/run/src/main/java/com/guide/run/user/service/UserService.java
+++ b/run/src/main/java/com/guide/run/user/service/UserService.java
@@ -1,18 +1,12 @@
 package com.guide.run.user.service;
 
-import com.guide.run.global.exception.user.dto.InvalidItemErrorException;
 import com.guide.run.global.jwt.JwtProvider;
-import com.guide.run.user.dto.GuideSignupDto;
-import com.guide.run.user.dto.ViSignupDto;
-import com.guide.run.user.dto.response.SignupResponse;
-import com.guide.run.user.entity.*;
+import com.guide.run.user.entity.User;
 import com.guide.run.user.entity.type.Role;
-import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -21,12 +15,7 @@ import java.util.UUID;
 @Service
 @Slf4j
 public class UserService {
-    private final ViRepository viRepository;
-    private final GuideRepository guideRepository;
     private final UserRepository userRepository;
-    private final ArchiveDataRepository archiveDataRepository;
-    private final PermissionRepository permissionRepository;
-    private final JwtProvider jwtProvider;
 
     public String getUserStatus(String privateId){
         String reAssignSocialId = reAssignSocialId(privateId);
@@ -45,11 +34,6 @@ public class UserService {
         }
     }
 
-
-
-
-
-
     public String getUUID(){
         String id = UUID.randomUUID().toString();
         return id;
@@ -65,7 +49,7 @@ public class UserService {
             return "kakao_"+privateId.substring(6);
         }
         else{
-            return "Error";
+            return "Error"; //todo : 이 부분 에러코드 추가해야 합니다.
         }
     }
 
@@ -80,6 +64,10 @@ public class UserService {
                 .role(Role.NEW)
                 .build();
         userRepository.save(user);
+    }
+
+    public String extractNumber(String phoneNum){
+        return phoneNum.replaceAll("[^0-9]", "");
     }
 
 }

--- a/run/src/main/java/com/guide/run/user/service/ViService.java
+++ b/run/src/main/java/com/guide/run/user/service/ViService.java
@@ -30,15 +30,16 @@ public class ViService {
     public SignupResponse viSignup(String privateId, ViSignupDto viSignupDto){
         User user = userRepository.findById(userService.reAssignReturn(privateId)).orElse(null);
         if(user!=null) {
-            log.info("에러발생");
+            log.info("에러발생"); //todo : 에러코드 추가해야 합니다.
             return null; //기가입자나 이미 정보를 입력한 회원이 재요청한 경우 이므로 에러 코드 추가
         } else {
+            String phoneNum = userService.extractNumber(viSignupDto.getPhoneNumber());
             User vi = User.builder()
                     .userId(userService.getUUID())
                     .privateId(privateId)
                     .name(viSignupDto.getName())
                     .gender(viSignupDto.getGender())
-                    .phoneNumber(viSignupDto.getPhoneNumber())
+                    .phoneNumber(phoneNum)
                     .openNumber(viSignupDto.isOpenNumber())
                     .age(viSignupDto.getAge())
                     .detailRecord(viSignupDto.getDetailRecord())

--- a/run/src/main/java/com/guide/run/user/service/ViService.java
+++ b/run/src/main/java/com/guide/run/user/service/ViService.java
@@ -1,0 +1,90 @@
+package com.guide.run.user.service;
+
+import com.guide.run.global.jwt.JwtProvider;
+import com.guide.run.user.dto.ViSignupDto;
+import com.guide.run.user.dto.response.SignupResponse;
+import com.guide.run.user.entity.ArchiveData;
+import com.guide.run.user.entity.Permission;
+import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.Vi;
+import com.guide.run.user.entity.type.Role;
+import com.guide.run.user.entity.type.UserType;
+import com.guide.run.user.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class ViService {
+    private final ViRepository viRepository;
+    private final UserRepository userRepository;
+    private final ArchiveDataRepository archiveDataRepository;
+    private final PermissionRepository permissionRepository;
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
+
+    @Transactional
+    public SignupResponse viSignup(String privateId, ViSignupDto viSignupDto){
+        User user = userRepository.findById(userService.reAssignReturn(privateId)).orElse(null);
+        if(user!=null) {
+            log.info("에러발생");
+            return null; //기가입자나 이미 정보를 입력한 회원이 재요청한 경우 이므로 에러 코드 추가
+        } else {
+            User vi = User.builder()
+                    .userId(userService.getUUID())
+                    .privateId(privateId)
+                    .name(viSignupDto.getName())
+                    .gender(viSignupDto.getGender())
+                    .phoneNumber(viSignupDto.getPhoneNumber())
+                    .openNumber(viSignupDto.isOpenNumber())
+                    .age(viSignupDto.getAge())
+                    .detailRecord(viSignupDto.getDetailRecord())
+                    .recordDegree(viSignupDto.getRecordDegree())
+                    .role(Role.WAIT)
+                    .type(UserType.VI)
+                    .snsId(viSignupDto.getSnsId())
+                    .openSns(viSignupDto.isOpenSns())
+                    .build();
+
+            Vi viInfo = Vi.builder()
+                    .privateId(privateId)
+                    .runningExp(viSignupDto.isRunningExp())
+                    .guideName(viSignupDto.getGuideName())
+                    .build();
+
+            userRepository.delete(userRepository.findById(privateId).orElse(null)); //임시 유저 삭제
+
+            User newVi = userRepository.save(vi);
+            viRepository.save(viInfo);
+
+            ArchiveData archiveData = ArchiveData.builder()
+                    .privateId(privateId)
+                    .howToKnow(viSignupDto.getHowToKnow())
+                    .motive(viSignupDto.getMotive())
+                    .runningPlace(viSignupDto.getRunningPlace())
+                    .build();
+
+            archiveDataRepository.save(archiveData); //안 쓰는 데이터 저장
+
+            Permission permission = Permission.builder()
+                    .privateId(privateId)
+                    .privacy(viSignupDto.isPrivacy())
+                    .portraitRights(viSignupDto.isPortraitRights())
+                    .build();
+
+            permissionRepository.save(permission); //약관 동의 저장
+
+            SignupResponse response = SignupResponse
+                    .builder()
+                    .accessToken(jwtProvider.createAccessToken(privateId))
+                    .uuid(newVi.getUserId())
+                    .userStatus(newVi.getRole().getValue())
+                    .build();
+
+            return response;
+        }
+    }
+}


### PR DESCRIPTION

[JIRA 태스크 링크](https://guide-run-project.atlassian.net/browse/GUIDE-83)

- 입력되는 전화번호에 패턴을 적용하고, db에 저장 시 하이픈이나 공백문자 없이 숫자만 저장되도록 구현
    - 적용된 패턴은 010-1234-1234, 010 1234 1234, 01012341234 세 가지 형태로 input이 가능하도록 함
    - 이외 패턴으로 전화번호가 request body에 들어오면 400 bad request 발생 -> 예외 코드 추가할 예정
- 기존에 사용하던 UserService의 부피가 커져서 GuideService와 ViService로 파일을 분리
    - reAssignSocialId 메소드가 private이기 때문에 실행해주는 public 메소드인 reAssignReturn을 따로 구현. reAssignSocialId를 public으로 변경해도 무방하다면 삭제해도 될 것 같다. 
