### PR TITLE
GUIDE-82 회원가입 시 기존 정보 연동 + 기존 정보 업로드를 위한 api 작성

### DIFF
--- a/run/build.gradle
+++ b/run/build.gradle
@@ -27,6 +27,9 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.apache.poi:poi:5.2.3' //엑셀 불러오기용. 기존 데이터 저장 후 삭제할 예정.
+	implementation 'org.apache.poi:poi-ooxml:5.2.3' //엑셀 불러오기용2
+
 	implementation 'net.rakugakibox.util:yaml-resource-bundle:1.1'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/run/src/main/java/com/guide/run/event/controller/EventController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventController.java
@@ -8,7 +8,7 @@ import com.guide.run.event.service.EventService;
 import com.guide.run.global.exception.admin.authorize.NotAuthorityAdminException;
 import com.guide.run.global.exception.user.resource.NotExistUserException;
 import com.guide.run.global.jwt.JwtProvider;
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;

--- a/run/src/main/java/com/guide/run/event/entity/Event.java
+++ b/run/src/main/java/com/guide/run/event/entity/Event.java
@@ -2,14 +2,12 @@ package com.guide.run.event.entity;
 
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,8 +25,10 @@ public class Event{
     private LocalDate recruitStartDate;//모집 시작일
     private LocalDate recruitEndDate;//모집 마감일
     private String name; //이벤트 제목
+    @Enumerated(EnumType.STRING)
     private EventRecruitStatus recruitStatus; // event 모집 상태 대기,모집중,모집마감
     private boolean isApprove; // 이벤트 승인 여부
+    @Enumerated(EnumType.STRING)
     private EventType type;//이벤트 분류
     private LocalDateTime startTime;//이벤트 시작일+ 시작시간
     private LocalDateTime endTime;//이벤트 종료일 + 이벤트 종료 시간
@@ -36,4 +36,8 @@ public class Event{
     private int maxNumG;//guide 모집 인원
     private String place;//이벤트 장소
     private String content;//이벤트 내용
+
+    //이 부분 추가됐습니다~
+    private int viCnt; //실제 모집된 vi 수
+    private int guideCnt; //실제 모집된 guide 수
 }

--- a/run/src/main/java/com/guide/run/event/entity/EventForm.java
+++ b/run/src/main/java/com/guide/run/event/entity/EventForm.java
@@ -3,10 +3,7 @@ package com.guide.run.event.entity;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import com.guide.run.global.entity.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,6 +32,8 @@ public class EventForm extends BaseEntity {
     //새로 추가한 부분
     private LocalDateTime startTime;//이벤트 시작일+ 시작시간
     private LocalDateTime endTime;//이벤트 종료일 + 이벤트 종료 시간
+    @Enumerated(EnumType.STRING)
     private EventType eventType;
+    @Enumerated(EnumType.STRING)
     private EventRecruitStatus recruitStatus;
 }

--- a/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
+++ b/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
@@ -28,6 +28,9 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer(){
         return web -> {
             web.ignoring()
+                    .requestMatchers("/member-upload")
+                    .requestMatchers("/event-upload")
+                    .requestMatchers("/attendance-upload")
                     .requestMatchers("/api/oauth/**");
         };
     }

--- a/run/src/main/java/com/guide/run/global/security/user/CustomUserDetails.java
+++ b/run/src/main/java/com/guide/run/global/security/user/CustomUserDetails.java
@@ -1,6 +1,6 @@
 package com.guide.run.global.security.user;
 
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.User;
 import lombok.AllArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/run/src/main/java/com/guide/run/global/security/user/CustomUserDetailsService.java
+++ b/run/src/main/java/com/guide/run/global/security/user/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.guide.run.global.security.user;
 
 import com.guide.run.global.exception.user.resource.NotExistUserException;
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/run/src/main/java/com/guide/run/temp/member/controller/ExcelController.java
+++ b/run/src/main/java/com/guide/run/temp/member/controller/ExcelController.java
@@ -1,0 +1,81 @@
+package com.guide.run.temp.member.controller;
+
+
+import com.guide.run.temp.member.dto.AttDTO;
+import com.guide.run.temp.member.dto.EventDTO;
+import com.guide.run.temp.member.dto.MemberDTO;
+import com.guide.run.temp.member.service.ExcelService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+public class ExcelController {
+
+    @Autowired
+    private ExcelService excelService;
+
+    @PostMapping("/member-upload")
+    public ResponseEntity<String> uploadMemberExcelFile(@RequestParam("file") MultipartFile file) {
+        if (file.isEmpty()) {
+            return new ResponseEntity<>("파일을 올려주세요", HttpStatus.BAD_REQUEST);
+        }
+
+        try {
+            List<MemberDTO> dataList = excelService.readMemberExcelData(file);
+            if (dataList != null && !dataList.isEmpty()) {
+                excelService.saveMemberExcelData(dataList);
+                return new ResponseEntity<>("성공", HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>("파일 오류", HttpStatus.BAD_REQUEST);
+            }
+        } catch (IOException e) {
+            return new ResponseEntity<>("실패 " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PostMapping("/event-upload")
+    public ResponseEntity<String> uploadEventExcelFile(@RequestParam("file") MultipartFile file) {
+        if (file.isEmpty()) {
+            return new ResponseEntity<>("파일을 올려주세요", HttpStatus.BAD_REQUEST);
+        }
+
+        try {
+            List<EventDTO> dataList = excelService.readEventExcelData(file);
+            if (dataList != null && !dataList.isEmpty()) {
+                excelService.saveEventExcelData(dataList);
+                return new ResponseEntity<>("성공", HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>("파일 오류", HttpStatus.BAD_REQUEST);
+            }
+        } catch (IOException e) {
+            return new ResponseEntity<>("실패 " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PostMapping("/attendance-upload")
+    public ResponseEntity<String> uploadAttExcelFile(@RequestParam("file") MultipartFile file) {
+        if (file.isEmpty()) {
+            return new ResponseEntity<>("파일을 올려주세요", HttpStatus.BAD_REQUEST);
+        }
+
+        try {
+            List<AttDTO> dataList = excelService.readAttData(file);
+            if (dataList != null && !dataList.isEmpty()) {
+                excelService.saveAttData(dataList);
+                return new ResponseEntity<>("성공", HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>("파일 오류", HttpStatus.BAD_REQUEST);
+            }
+        } catch (IOException e) {
+            return new ResponseEntity<>("실패 " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/run/src/main/java/com/guide/run/temp/member/dto/AttDTO.java
+++ b/run/src/main/java/com/guide/run/temp/member/dto/AttDTO.java
@@ -1,0 +1,20 @@
+package com.guide.run.temp.member.dto;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AttDTO {
+    private Long privateId;
+    private Long eventId;
+    private boolean isAttend;
+    private LocalDateTime date;
+}

--- a/run/src/main/java/com/guide/run/temp/member/dto/EventDTO.java
+++ b/run/src/main/java/com/guide/run/temp/member/dto/EventDTO.java
@@ -1,0 +1,32 @@
+package com.guide.run.temp.member.dto;
+
+import com.guide.run.event.entity.type.EventRecruitStatus;
+import com.guide.run.event.entity.type.EventType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EventDTO {
+    private Long id; //이벤트 id
+    private String organizer = "admin"; //주최자 id
+    private String name; //이벤트 제목
+    private EventRecruitStatus recruitStatus = EventRecruitStatus.END; // event 모집 상태 대기,모집중,모집마감
+    private boolean isApprove = true; // 이벤트 승인 여부
+    private EventType type;//이벤트 분류
+    private LocalDateTime startTime;//이벤트 시작일+ 시작시간
+    private LocalDateTime endTime;//이벤트 종료일 + 이벤트 종료 시간
+    private String place;//이벤트 장소
+    private String content;//이벤트 내용
+    private int viCnt; //실제 모집된 vi 수
+    private int guideCnt; //실제 모집된 guide 수
+}

--- a/run/src/main/java/com/guide/run/temp/member/dto/MemberDTO.java
+++ b/run/src/main/java/com/guide/run/temp/member/dto/MemberDTO.java
@@ -1,0 +1,15 @@
+package com.guide.run.temp.member.dto;
+
+import lombok.Data;
+
+@Data
+public class MemberDTO {
+    private Long id;
+    private String name;
+    private String type;
+    private String gender;
+    private String phoneNumber;
+    private int age;
+    private String detailRecord;
+    private String recordDegree;
+}

--- a/run/src/main/java/com/guide/run/temp/member/entity/Attendance.java
+++ b/run/src/main/java/com/guide/run/temp/member/entity/Attendance.java
@@ -1,0 +1,28 @@
+package com.guide.run.temp.member.entity;
+
+import com.guide.run.user.entity.partner.PartnerId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@IdClass(AttendanceId.class)
+public class Attendance {
+    @Id
+    private String privateId;
+    @Id
+    private Long eventId;
+    private boolean isAttend;
+    private LocalDateTime date;
+
+}

--- a/run/src/main/java/com/guide/run/temp/member/entity/AttendanceId.java
+++ b/run/src/main/java/com/guide/run/temp/member/entity/AttendanceId.java
@@ -1,0 +1,15 @@
+package com.guide.run.temp.member.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AttendanceId implements Serializable {
+    private String privateId;
+    private Long eventId;
+}

--- a/run/src/main/java/com/guide/run/temp/member/entity/Member.java
+++ b/run/src/main/java/com/guide/run/temp/member/entity/Member.java
@@ -1,0 +1,23 @@
+package com.guide.run.temp.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "member")
+public class Member {
+    @Id
+    private Long id;
+    private String name;
+    private String type;
+    private String gender;
+    private String phoneNumber;
+    private int age;
+    private String detailRecord;
+    private String recordDegree;
+}

--- a/run/src/main/java/com/guide/run/temp/member/repository/AttendanceRepository.java
+++ b/run/src/main/java/com/guide/run/temp/member/repository/AttendanceRepository.java
@@ -1,0 +1,12 @@
+package com.guide.run.temp.member.repository;
+
+import com.guide.run.temp.member.entity.Attendance;
+import com.guide.run.temp.member.entity.AttendanceId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AttendanceRepository extends JpaRepository<Attendance, AttendanceId> {
+    List<Attendance> findAllByPrivateId(String privateId);
+}

--- a/run/src/main/java/com/guide/run/temp/member/repository/MemberRepository.java
+++ b/run/src/main/java/com/guide/run/temp/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.guide.run.temp.member.repository;
+
+import com.guide.run.temp.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByPhoneNumber(String phone);
+}

--- a/run/src/main/java/com/guide/run/temp/member/service/ExcelService.java
+++ b/run/src/main/java/com/guide/run/temp/member/service/ExcelService.java
@@ -1,0 +1,310 @@
+package com.guide.run.temp.member.service;
+
+import com.guide.run.event.entity.Event;
+import com.guide.run.event.entity.repository.EventRepository;
+import com.guide.run.event.entity.type.EventRecruitStatus;
+import com.guide.run.event.entity.type.EventType;
+import com.guide.run.temp.member.dto.AttDTO;
+import com.guide.run.temp.member.dto.EventDTO;
+import com.guide.run.temp.member.dto.MemberDTO;
+import com.guide.run.temp.member.entity.Attendance;
+import com.guide.run.temp.member.repository.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@Slf4j
+public class ExcelService {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    public List<MemberDTO> readMemberExcelData(MultipartFile file) throws IOException {
+        List<MemberDTO> dataList = new ArrayList<>();
+
+        try (Workbook workbook = WorkbookFactory.create(file.getInputStream())) {
+            Sheet sheet = workbook.getSheetAt(0);
+
+            for (Row row : sheet) {
+                if(row.getRowNum()==0){
+                    continue;
+                }
+                MemberDTO dto = new MemberDTO();
+                //id, name, type, gender, phoneNumber, age, datailRecord, recordDegree
+                Cell idCell = row.getCell(0);
+                if(idCell !=null){
+                    dto.setId(getLongValue(idCell));
+                }
+
+                Cell nameCell = row.getCell(1);
+                if (nameCell != null) {
+                    dto.setName(getStringValue(nameCell));
+                }
+
+                Cell typeCell = row.getCell(2);
+                if (typeCell != null) {
+                    dto.setType(getStringValue(typeCell));
+                }
+
+                Cell phoneNumberCell = row.getCell(3);
+                if (phoneNumberCell != null) {
+                    dto.setPhoneNumber(getStringValue(phoneNumberCell));
+                }
+
+                Cell genderCell = row.getCell(4);
+                if (genderCell != null) {
+                    dto.setGender(getStringValue(genderCell));
+                }
+
+                Cell ageCell = row.getCell(5);
+                if (ageCell != null && ageCell.getCellType() == CellType.NUMERIC) {
+                    dto.setAge((int) ageCell.getNumericCellValue());
+                }
+
+                Cell detailRecordCell = row.getCell(6);
+                if (detailRecordCell != null) {
+                    dto.setDetailRecord(getStringValue(detailRecordCell));
+                }
+
+                Cell recordDegreeCell = row.getCell(7);
+                if (recordDegreeCell != null) {
+                    dto.setRecordDegree(getStringValue(recordDegreeCell));
+                }
+
+                dataList.add(dto);
+            }
+        }
+
+        return dataList;
+    }
+
+    public void saveMemberExcelData(List<MemberDTO> dataList) {
+        final int batchSize = 500;
+
+        for (int i = 0; i < dataList.size(); i += batchSize) {
+            final List<MemberDTO> batchList = dataList.subList(i, Math.min(i + batchSize, dataList.size()));
+            jdbcTemplate.batchUpdate("INSERT INTO member (id, name, type, gender, phone_number, age, detail_record, record_degree) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    new BatchPreparedStatementSetter() {
+                        @Override
+                        public void setValues(PreparedStatement preparedStatement, int i) throws SQLException {
+                            MemberDTO dto = batchList.get(i);
+                            preparedStatement.setLong(1, dto.getId());
+                            preparedStatement.setString(2,dto.getName());
+                            preparedStatement.setString(3,dto.getType());
+                            preparedStatement.setString(4,dto.getGender());
+                            preparedStatement.setString(5,dto.getPhoneNumber());
+                            preparedStatement.setInt(6, dto.getAge());
+                            preparedStatement.setString(7, dto.getDetailRecord());
+                            preparedStatement.setString(8,dto.getRecordDegree());
+                        }
+
+                        @Override
+                        public int getBatchSize() {
+                            return batchList.size();
+                        }
+                    });
+        }
+    }
+
+    public List<EventDTO> readEventExcelData(MultipartFile file) throws IOException {
+        List<EventDTO> dataList = new ArrayList<>();
+
+        try (Workbook workbook = WorkbookFactory.create(file.getInputStream())) {
+            Sheet sheet = workbook.getSheetAt(0);
+
+            for (Row row : sheet) {
+                if (row.getRowNum() <2) {
+                    continue;
+                }
+                if(row.getRowNum()>=45){
+                    break;
+                }
+                //log.info(String.valueOf(row.getRowNum()));
+                    EventDTO dto = new EventDTO();
+                    //id, name, type, startTime, endTime, viCnt, guideCnt, place, content
+                    Cell idCell = row.getCell(1);
+                    if (idCell != null) {
+                        dto.setId(getLongValue(idCell));
+                    }
+
+                    Cell nameCell = row.getCell(2);
+                    if (nameCell != null) {
+                        dto.setName(getStringValue(nameCell));
+                    }
+
+                    Cell typeCell = row.getCell(3);
+                    if (typeCell != null) {
+                        dto.setType(getEventType(typeCell));
+                    }
+
+                    Cell startTimeCell = row.getCell(5);
+                    if (startTimeCell != null) {
+                        dto.setStartTime(getDateTime(startTimeCell));
+                    }
+
+                    Cell endTimeCell = row.getCell(6);
+                    if (endTimeCell != null) {
+                        dto.setEndTime(getDateTime(endTimeCell));
+                    }
+
+                    Cell viCntCell = row.getCell(7);
+                    if (viCntCell != null && viCntCell.getCellType() == CellType.NUMERIC) {
+                        dto.setViCnt((int) viCntCell.getNumericCellValue());
+                    }
+
+                    Cell guideCntCell = row.getCell(8);
+                    if (guideCntCell != null && guideCntCell.getCellType() == CellType.NUMERIC) {
+                        dto.setGuideCnt((int) guideCntCell.getNumericCellValue());
+                    }
+
+                    Cell placeCell = row.getCell(9);
+                    if (placeCell != null) {
+                        dto.setPlace(getStringValue(placeCell));
+                    }
+
+                    Cell contentCell = row.getCell(10);
+                    if (contentCell != null) {
+                        dto.setContent(getStringValue(contentCell));
+                    }
+
+                    dataList.add(dto);
+            }
+        }
+
+        return dataList;
+    }
+
+
+    public void saveEventExcelData(List<EventDTO> dataList) {
+        for (EventDTO data : dataList) {
+            Event event = Event.builder()
+                    .id(data.getId())
+                    .organizer(data.getOrganizer())
+                    .name(data.getName())
+                    .recruitStatus(data.getRecruitStatus())
+                    .isApprove(data.isApprove())
+                    .startTime(data.getStartTime())
+                    .endTime(data.getEndTime())
+                    .place(data.getPlace())
+                    .viCnt(data.getViCnt())
+                    .guideCnt(data.getGuideCnt())
+                    .type(data.getType())
+                    .content(data.getContent())
+                    .build();
+
+            eventRepository.save(event);
+        }
+    }
+
+    public List<AttDTO> readAttData(MultipartFile file) throws IOException {
+        List<AttDTO> dataList = new ArrayList<>();
+
+        try (Workbook workbook = WorkbookFactory.create(file.getInputStream())) {
+            Sheet sheet = workbook.getSheetAt(0);
+
+            for (Row row : sheet) {
+                if(row.getRowNum()==0){
+                    continue;
+                }
+                AttDTO dto = new AttDTO();
+                //privateId, eventId, date
+                Cell idCell = row.getCell(0);
+                if(idCell !=null){
+                    dto.setPrivateId(getLongValue(idCell));
+                }
+
+                Cell eventIdCell = row.getCell(1);
+                if (eventIdCell != null) {
+                    dto.setEventId(getLongValue(eventIdCell));
+                }
+
+                Cell dateCell = row.getCell(2);
+                if (dateCell != null) {
+                    dto.setDate(getAttDate(dateCell));
+                }
+
+                dataList.add(dto);
+            }
+        }
+
+        return dataList;
+    }
+
+    public void saveAttData(List<AttDTO> dataList) {
+        final int batchSize = 500;
+
+        for (int i = 0; i < dataList.size(); i += batchSize) {
+            final List<AttDTO> batchList = dataList.subList(i, Math.min(i + batchSize, dataList.size()));
+            jdbcTemplate.batchUpdate("INSERT INTO attendance (private_id, event_id, is_attend, date) " +
+                            "VALUES (?, ?, ?, ?)",
+                    new BatchPreparedStatementSetter() {
+                        @Override
+                        public void setValues(PreparedStatement preparedStatement, int i) throws SQLException {
+                            AttDTO dto = batchList.get(i);
+                            preparedStatement.setString(1, String.valueOf(dto.getPrivateId()));
+                            preparedStatement.setLong(2,dto.getEventId());
+                            preparedStatement.setBoolean(3,true);
+                            preparedStatement.setObject(4, dto.getDate());
+                        }
+
+                        @Override
+                        public int getBatchSize() {
+                            return batchList.size();
+                        }
+                    });
+        }
+    }
+
+    private String getStringValue(Cell cell) {
+        if (cell != null) {
+            if (cell.getCellType() == CellType.STRING) {
+                return cell.getStringCellValue();
+            } else if (cell.getCellType() == CellType.NUMERIC) {
+                return String.valueOf(cell.getNumericCellValue());
+            }
+        }
+        return null;
+    }
+
+    private long getLongValue(Cell cell) {
+        if (cell != null && cell.getCellType() == CellType.NUMERIC) {
+            return (long) cell.getNumericCellValue();
+        }
+        return 0;
+    }
+
+    private LocalDateTime getDateTime(Cell cell){
+        //log.info(cell.getStringCellValue());
+        return LocalDateTime.parse(cell.getStringCellValue());
+    }
+
+    private LocalDateTime getAttDate(Cell cell){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return LocalDateTime.parse(cell.getStringCellValue(),formatter);
+    }
+    private EventType getEventType(Cell cell){
+        if(cell.getStringCellValue().equals("TRAINING")){
+            return EventType.TRAINING;
+        }else{
+            return EventType.COMPETITION;
+        }
+    }
+}

--- a/run/src/main/java/com/guide/run/temp/member/service/TmpService.java
+++ b/run/src/main/java/com/guide/run/temp/member/service/TmpService.java
@@ -1,0 +1,51 @@
+package com.guide.run.temp.member.service;
+
+import com.guide.run.temp.member.entity.Attendance;
+import com.guide.run.temp.member.entity.Member;
+import com.guide.run.temp.member.repository.AttendanceRepository;
+import com.guide.run.temp.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TmpService {
+    private final MemberRepository memberRepository;
+    private final AttendanceRepository attendanceRepository;
+    //기존에 있던 사람인지 확인
+    public Long getMember(String phone){
+        Optional<Member> member = memberRepository.findByPhoneNumber(phone);
+        if(member.isEmpty()){
+            return 0L;
+        }else{
+            return member.get().getId();
+        }
+    }
+    @Transactional
+    //이벤트 출석 정보 연결
+    public void updateMember(String phone, String privateId){
+        Long memberId = getMember(phone);
+        //임시 출석 정보
+        if(memberId != 0L){
+            List<Attendance> attendances = attendanceRepository.findAllByPrivateId(String.valueOf(memberId));
+            for(Attendance att : attendances){
+                Attendance updateAtt = Attendance.builder()
+                        .privateId(privateId)
+                        .eventId(att.getEventId())
+                        .isAttend(true)
+                        .date(att.getDate())
+                        .build();
+                attendanceRepository.delete(att);
+                attendanceRepository.save(updateAtt);
+            }
+        }
+
+    }
+}

--- a/run/src/main/java/com/guide/run/user/controller/TestController.java
+++ b/run/src/main/java/com/guide/run/user/controller/TestController.java
@@ -3,7 +3,7 @@ package com.guide.run.user.controller;
 
 import com.guide.run.global.exception.user.resource.NotExistUserException;
 import com.guide.run.user.entity.type.Role;
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;

--- a/run/src/main/java/com/guide/run/user/dto/GlobalUserInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/GlobalUserInfoDto.java
@@ -1,6 +1,6 @@
 package com.guide.run.user.dto;
 
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/run/src/main/java/com/guide/run/user/dto/GuideRunningInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/GuideRunningInfoDto.java
@@ -1,8 +1,8 @@
 package com.guide.run.user.dto;
 
 import com.guide.run.user.entity.ArchiveData;
-import com.guide.run.user.entity.Guide;
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.Guide;
+import com.guide.run.user.entity.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
@@ -1,6 +1,6 @@
 package com.guide.run.user.dto;
 
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/run/src/main/java/com/guide/run/user/dto/ViRunningInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/ViRunningInfoDto.java
@@ -1,8 +1,8 @@
 package com.guide.run.user.dto;
 
 import com.guide.run.user.entity.ArchiveData;
-import com.guide.run.user.entity.User;
-import com.guide.run.user.entity.Vi;
+import com.guide.run.user.entity.user.User;
+import com.guide.run.user.entity.user.Vi;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/run/src/main/java/com/guide/run/user/entity/partner/Partner.java
+++ b/run/src/main/java/com/guide/run/user/entity/partner/Partner.java
@@ -1,5 +1,7 @@
-package com.guide.run.user.entity;
+package com.guide.run.user.entity.partner;
 
+import com.guide.run.user.entity.user.Guide;
+import com.guide.run.user.entity.user.Vi;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/run/src/main/java/com/guide/run/user/entity/partner/PartnerId.java
+++ b/run/src/main/java/com/guide/run/user/entity/partner/PartnerId.java
@@ -1,4 +1,4 @@
-package com.guide.run.user.entity;
+package com.guide.run.user.entity.partner;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/run/src/main/java/com/guide/run/user/entity/user/Guide.java
+++ b/run/src/main/java/com/guide/run/user/entity/user/Guide.java
@@ -1,4 +1,4 @@
-package com.guide.run.user.entity;
+package com.guide.run.user.entity.user;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;

--- a/run/src/main/java/com/guide/run/user/entity/user/User.java
+++ b/run/src/main/java/com/guide/run/user/entity/user/User.java
@@ -1,4 +1,4 @@
-package com.guide.run.user.entity;
+package com.guide.run.user.entity.user;
 
 
 import com.guide.run.global.entity.BaseEntity;

--- a/run/src/main/java/com/guide/run/user/entity/user/Vi.java
+++ b/run/src/main/java/com/guide/run/user/entity/user/Vi.java
@@ -1,4 +1,4 @@
-package com.guide.run.user.entity;
+package com.guide.run.user.entity.user;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;

--- a/run/src/main/java/com/guide/run/user/repository/GuideRepository.java
+++ b/run/src/main/java/com/guide/run/user/repository/GuideRepository.java
@@ -1,6 +1,6 @@
 package com.guide.run.user.repository;
 
-import com.guide.run.user.entity.Guide;
+import com.guide.run.user.entity.user.Guide;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GuideRepository extends JpaRepository<Guide, String> {

--- a/run/src/main/java/com/guide/run/user/repository/PartnerRepository.java
+++ b/run/src/main/java/com/guide/run/user/repository/PartnerRepository.java
@@ -1,12 +1,8 @@
 package com.guide.run.user.repository;
 
-import com.guide.run.user.entity.Partner;
-import com.guide.run.user.entity.PartnerId;
+import com.guide.run.user.entity.partner.Partner;
+import com.guide.run.user.entity.partner.PartnerId;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface PartnerRepository extends JpaRepository<Partner, PartnerId> {
 

--- a/run/src/main/java/com/guide/run/user/repository/UserRepository.java
+++ b/run/src/main/java/com/guide/run/user/repository/UserRepository.java
@@ -1,13 +1,8 @@
 package com.guide.run.user.repository;
 
-import com.guide.run.user.entity.Guide;
-import com.guide.run.user.entity.User;
-import com.guide.run.user.entity.Vi;
-import org.springframework.data.jpa.repository.EntityGraph;
+import com.guide.run.user.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,String> {

--- a/run/src/main/java/com/guide/run/user/repository/ViRepository.java
+++ b/run/src/main/java/com/guide/run/user/repository/ViRepository.java
@@ -1,6 +1,6 @@
 package com.guide.run.user.repository;
 
-import com.guide.run.user.entity.Vi;
+import com.guide.run.user.entity.user.Vi;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ViRepository extends JpaRepository<Vi, String> {

--- a/run/src/main/java/com/guide/run/user/service/GuideService.java
+++ b/run/src/main/java/com/guide/run/user/service/GuideService.java
@@ -2,11 +2,14 @@ package com.guide.run.user.service;
 
 import com.guide.run.global.exception.user.authorize.ExistUserException;
 import com.guide.run.global.jwt.JwtProvider;
+import com.guide.run.temp.member.service.TmpService;
 import com.guide.run.user.dto.GuideSignupDto;
 import com.guide.run.user.dto.response.SignupResponse;
 import com.guide.run.user.entity.*;
 import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.entity.type.UserType;
+import com.guide.run.user.entity.user.Guide;
+import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +30,8 @@ public class GuideService {
     private final PasswordEncoder bCryptPasswordEncoder;
     private final SignUpInfoRepository signUpInfoRepository;
 
+    private final TmpService tmpService;
+
     @Transactional
     public SignupResponse guideSignup(String privateId, GuideSignupDto guideSignupDto){
         User user = userRepository.findById(privateId).orElse(null);
@@ -35,6 +40,10 @@ public class GuideService {
             throw new ExistUserException();
         } else {
             String phoneNum = userService.extractNumber(guideSignupDto.getPhoneNumber());
+
+            //가입 전 회원정보 연결
+            tmpService.updateMember(phoneNum, privateId);
+
             User guide = User.builder()
                     .userId(userService.getUUID())
                     .privateId(privateId)

--- a/run/src/main/java/com/guide/run/user/service/MypageService.java
+++ b/run/src/main/java/com/guide/run/user/service/MypageService.java
@@ -2,7 +2,7 @@ package com.guide.run.user.service;
 
 import com.guide.run.global.exception.user.resource.NotExistUserException;
 import com.guide.run.user.dto.GlobalUserInfoDto;
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
+++ b/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
@@ -1,12 +1,14 @@
 package com.guide.run.user.service;
 
-import com.guide.run.global.exception.user.dto.InvalidItemErrorException;
 import com.guide.run.global.exception.user.resource.NotExistUserException;
 import com.guide.run.user.dto.GuideRunningInfoDto;
 import com.guide.run.user.dto.PermissionDto;
 import com.guide.run.user.dto.PersonalInfoDto;
 import com.guide.run.user.dto.ViRunningInfoDto;
 import com.guide.run.user.entity.*;
+import com.guide.run.user.entity.user.Guide;
+import com.guide.run.user.entity.user.User;
+import com.guide.run.user.entity.user.Vi;
 import com.guide.run.user.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/run/src/main/java/com/guide/run/user/service/UserService.java
+++ b/run/src/main/java/com/guide/run/user/service/UserService.java
@@ -1,8 +1,7 @@
 package com.guide.run.user.service;
 
-import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.user.entity.SignUpInfo;
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.User;
 import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.repository.*;
 import lombok.RequiredArgsConstructor;

--- a/run/src/main/java/com/guide/run/user/service/ViService.java
+++ b/run/src/main/java/com/guide/run/user/service/ViService.java
@@ -2,11 +2,14 @@ package com.guide.run.user.service;
 
 import com.guide.run.global.exception.user.authorize.ExistUserException;
 import com.guide.run.global.jwt.JwtProvider;
+import com.guide.run.temp.member.service.TmpService;
 import com.guide.run.user.dto.ViSignupDto;
 import com.guide.run.user.dto.response.SignupResponse;
 import com.guide.run.user.entity.*;
 import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.entity.type.UserType;
+import com.guide.run.user.entity.user.User;
+import com.guide.run.user.entity.user.Vi;
 import com.guide.run.user.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +31,8 @@ public class ViService {
     private final PasswordEncoder bCryptPasswordEncoder;
     private final SignUpInfoRepository signUpInfoRepository;
 
+    private final TmpService tmpService;
+
     @Transactional
     public SignupResponse viSignup(String privateId, ViSignupDto viSignupDto){
         User user = userRepository.findById(privateId).orElse(null);
@@ -36,6 +41,10 @@ public class ViService {
             throw new ExistUserException(); //기가입자나 이미 정보를 입력한 회원이 재요청한 경우 이므로 에러 코드 추가
         } else {
             String phoneNum = userService.extractNumber(viSignupDto.getPhoneNumber());
+
+            //가입 전 회원정보 연결
+            tmpService.updateMember(phoneNum, privateId);
+
             User vi = User.builder()
                     .userId(userService.getUUID())
                     .privateId(privateId)

--- a/run/src/test/java/com/guide/run/user/service/UserServiceTest.java
+++ b/run/src/test/java/com/guide/run/user/service/UserServiceTest.java
@@ -1,9 +1,8 @@
 package com.guide.run.user.service;
 
 import com.guide.run.user.entity.type.Role;
-import com.guide.run.user.entity.User;
+import com.guide.run.user.entity.user.User;
 
-import com.guide.run.user.entity.Vi;
 import com.guide.run.user.repository.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,8 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.UUID;
 
 @SpringBootTest
 class UserServiceTest {


### PR DESCRIPTION
- temp 패키지를 만들었습니다. 
- 패키지 내부에 엑셀 파일을 받아서 업로드하는 api와 회원가입 시 기존 정보를 확인 후 출석 정보를 연동하는 코드 추가했습니다.
- member(기존 회원), attendance(출석) entity가 추가되었고, 둘 다 temp 패키지 안에 있습니다.
- 기존 회원을 연동 후 삭제하도록 할까 하다가, 한 사람이 여러 계정으로 가입할 수 있을 것 같아서 일단 그대로 뒀습니다.
- 출석 정보 연동은 전화번호로 확인한 다음 id만 privateId로 바꾸려고 했는데 JPA에서 pk는 변경이 불가능해서 그냥 지우고 새로 저장하는 방식으로 구현했습니다.