### PR TITLE
fix : 유저 매칭 리스트 이름순으로 정렬

### DIFF
--- a/run/src/main/java/com/guide/run/attendance/repository/AttendanceRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/attendance/repository/AttendanceRepositoryImpl.java
@@ -45,7 +45,7 @@ public class AttendanceRepositoryImpl implements AttendanceCustomRepository{
                 .join(user).on(attendance.privateId.eq(user.privateId))
                 .join(eventForm).on(attendance.privateId.eq(eventForm.privateId).and(eventForm.eventId.eq(eventId)))
                 .where(attendance.isAttend.eq(isAttend).and(attendance.eventId.eq(eventId)))
-                .orderBy(user.type.desc())
+                .orderBy(user.type.desc(),user.name.asc())
                 .fetch();
     }
 

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepositoryImpl.java
@@ -60,6 +60,7 @@ public class EventFormRepositoryImpl implements EventFormRepositoryCustom{
                 .from(eventForm)
                 .join(user).on(eventForm.privateId.eq(user.privateId).and(eventForm.eventId.eq(eventId)))
                 .where(eventForm.eventId.eq(eventId).and(user.type.eq(userType)))
+                .orderBy(user.name.asc())
                 .fetch();
     }
 
@@ -74,6 +75,7 @@ public class EventFormRepositoryImpl implements EventFormRepositoryCustom{
                 .from(eventForm)
                 .join(user).on(eventForm.privateId.eq(user.privateId).and(eventForm.eventId.eq(eventId)))
                 .where(eventForm.eventId.eq(eventId).and(user.type.eq(userType)))
+                .orderBy(user.name.asc())
                 .fetch();
     }
 }

--- a/run/src/main/java/com/guide/run/partner/entity/matching/repository/MatchingRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/partner/entity/matching/repository/MatchingRepositoryImpl.java
@@ -39,6 +39,7 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                 .join(user).on(user.privateId.eq(matching.guideId))
                 .join(eventForm).on(user.privateId.eq(eventForm.privateId).and(eventForm.eventId.eq(eventId)))
                 .join(attendance).on(user.privateId.eq(attendance.privateId).and(attendance.eventId.eq(eventId)))
+                .orderBy(user.name.asc())
                 .fetch();
     }
 
@@ -56,6 +57,7 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                 .join(eventForm).on(user.privateId.eq(eventForm.privateId).and(eventForm.eventId.eq(eventId)))
                 .join(attendance).on(user.privateId.eq(attendance.privateId).and(attendance.eventId.eq(eventId)))
                 .where(matching.eventId.eq(eventId).and(user.type.eq(userType)))
+                .orderBy(user.name.asc())
                 .distinct()
                 .fetch();
     }

--- a/run/src/main/java/com/guide/run/partner/entity/matching/repository/UnMatchingRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/partner/entity/matching/repository/UnMatchingRepositoryImpl.java
@@ -45,6 +45,7 @@ public class UnMatchingRepositoryImpl implements UnMatchingRepositoryCustom
                 .join(eventForm).on(unMatching.privateId.eq(eventForm.privateId).and(eventForm.eventId.eq(eventId)))
                 .join(attendance).on(unMatching.privateId.eq(attendance.privateId).and(attendance.eventId.eq(eventId)))
                 .where(unMatching.eventId.eq(eventId))
+                .orderBy(user.name.asc())
                 .fetch();
     }
 }


### PR DESCRIPTION
<!-- 풀리퀘 제목 -->
<!-- <TYPE>: 설명 <IssueNumber> -->

## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
매칭 리스트 api들 이름순으로 나오도록 수정

## **변경 내용**
변경 내용/로직을 추가합니다.

## **관련 이슈**
Resolves: #123 ...(해결한 이슈 번호)

See also: #45 #6 ...(참고 이슈 번호)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 개선/리팩터
  - 참석자 참여 정보 목록이 동일한 사용자 유형 내에서 사용자 이름 오름차순으로 안정적으로 정렬됩니다.
  - 이벤트 신청서 목록(전화번호 포함/미포함)이 사용자 이름 오름차순으로 정렬되어 탐색성이 향상되었습니다.
  - 매칭 및 미매칭 사용자 목록이 사용자 이름 오름차순으로 정렬되어 결과 표시가 일관됩니다.
- 버그 수정
  - 목록 정렬 기준이 불명확하거나 일관되지 않던 케이스를 개선해 예측 가능한 순서로 표시되도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->