### PR TITLE
docs: 프론트 사용처 기준으로 Swagger 문서 구체화

### DIFF
--- a/run/docs/swagger-contract-gaps.md
+++ b/run/docs/swagger-contract-gaps.md
@@ -1,0 +1,16 @@
+# Swagger Contract Gaps
+
+Swagger 문서는 실제 백엔드 계약을 기준으로 작성한다. 아래 항목은 프론트 helper 또는 mock과 현재 서버 구현 사이에 확인된 차이이며, 이번 작업에서는 문서화만 정리하고 런타임 계약은 변경하지 않았다.
+
+## 확인된 괴리
+
+### `GET /api/user/event-history/count/{userId}`
+
+- 백엔드 컨트롤러는 query parameter 이름으로 `kind`를 받는다.
+- 현재 프론트 helper `infoApi.eventHistoryCountGet`는 `sort`를 보내고 있다.
+- Swagger에는 실제 서버 계약인 `kind` 기준으로 반영한다.
+
+### `GET /api/user/mypage`
+
+- 프론트 request helper와 mock handler에는 존재하지만, 현재 백엔드 컨트롤러에서는 동일 경로를 확인하지 못했다.
+- 실제 프론트 화면의 사용처는 확인되지 않았으므로 이번 Swagger 보강 범위에서는 제외한다.

--- a/run/src/main/java/com/guide/run/admin/controller/AdminEventController.java
+++ b/run/src/main/java/com/guide/run/admin/controller/AdminEventController.java
@@ -8,6 +8,9 @@ import com.guide.run.admin.dto.response.Guide1365Response;
 import com.guide.run.admin.dto.response.event.*;
 import com.guide.run.admin.service.AdminEventService;
 import com.guide.run.event.entity.dto.response.get.Count;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,16 +20,20 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
+@Tag(name = "Admin Event", description = "관리자 이벤트 목록, 승인, 결과, 신청자 조회 API")
+@SecurityRequirement(name = "bearerAuth")
 public class AdminEventController {
 
     private final AdminEventService adminEventService;
 
     //전체 이벤트
+    @Operation(summary = "관리자 이벤트 목록 개수 조회", description = "관리자 이벤트 목록 화면의 전체 건수를 조회합니다.")
     @GetMapping("/event-list/count")
     public ResponseEntity<Count> getAllEventCount(){
         return ResponseEntity.status(200).
                 body(adminEventService.getAllEventCount());
     }
+    @Operation(summary = "관리자 이벤트 목록 조회", description = "관리자 이벤트 목록 화면에서 필터와 페이지네이션 조건에 맞는 이벤트 목록을 조회합니다.")
     @GetMapping("/event-list")
     public ResponseEntity<AdminEventList> getAllEvent(@RequestParam(defaultValue = "0") int start,
                                                       @RequestParam(defaultValue = "10") int limit,
@@ -48,6 +55,7 @@ public class AdminEventController {
         return ResponseEntity.status(200).body(response);
     }
 
+    @Operation(summary = "현재 진행/예정 이벤트 조회", description = "관리자 메인 화면에서 현재 노출할 이벤트 목록을 조회합니다.")
     @GetMapping("/current-event")
     public ResponseEntity<CurrentEventList> getCurrentEvent(@RequestParam(defaultValue = "0") int start,
                                                             @RequestParam(defaultValue = "4") int limit){
@@ -58,6 +66,7 @@ public class AdminEventController {
     }
 
     //유저 이벤트 히스토리
+    @Operation(summary = "특정 사용자 이벤트 이력 조회", description = "관리자 사용자 상세의 이벤트 탭에서 특정 사용자의 이벤트 이력을 조회합니다.")
     @GetMapping("/event-list/{userId}")
     public ResponseEntity<AdminEventHistoryList> getUserEventHistories(@PathVariable String userId,
                                                                        @RequestParam("start") int start,
@@ -70,6 +79,7 @@ public class AdminEventController {
         return ResponseEntity.status(200).body(response);
     }
 
+    @Operation(summary = "특정 사용자 이벤트 이력 개수 조회", description = "관리자 사용자 상세의 이벤트 탭에서 특정 사용자의 이벤트 이력 개수를 조회합니다.")
     @GetMapping("/event-list/count/{userId}")
     public ResponseEntity<Count> getUserEventHistoryCount(@PathVariable String userId,
                                                           @RequestParam(defaultValue = "all") String kind){
@@ -77,6 +87,7 @@ public class AdminEventController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "특정 사용자 이벤트 유형별 참여 수 조회", description = "관리자 사용자 상세의 이벤트 탭에서 훈련/대회 참여 건수를 조회합니다.")
     @GetMapping("/event-type/count/{userId}")
     public ResponseEntity<EventTypeCountDto> getUserEventHistoryCount(@PathVariable String userId){
         return ResponseEntity.status(200).
@@ -84,6 +95,7 @@ public class AdminEventController {
     }
 
     //단일 이벤트
+    @Operation(summary = "이벤트 승인/반려 처리", description = "관리자 이벤트 다이얼로그에서 이벤트 승인 상태를 변경합니다.")
     @PostMapping("/approval-event/{eventId}")
     public ResponseEntity<String> approvalEvent(@PathVariable long eventId,
                                                 @RequestBody ApprovalEvent approvalEvent){
@@ -91,11 +103,13 @@ public class AdminEventController {
         return ResponseEntity.ok().body("");
     }
 
+    @Operation(summary = "이벤트 결과 요약 조회", description = "관리자 이벤트 결과 패널에서 이벤트 결과와 불참 현황을 조회합니다.")
     @GetMapping("event-result/{eventId}")
     public ResponseEntity<AdminEventResult> getEventResult(@PathVariable long eventId){
         return ResponseEntity.ok(adminEventService.getEventResult(eventId));
     }
 
+    @Operation(summary = "이벤트 신청자 목록 조회", description = "관리자 이벤트 상세의 신청자 패널에서 필터와 페이지네이션 조건에 맞는 신청자 목록을 조회합니다.")
     @GetMapping("apply-list/{eventId}")
     public ResponseEntity<AdminEventApplyList> getEventApply(@PathVariable long eventId,
                                                              @RequestParam int start,
@@ -114,6 +128,7 @@ public class AdminEventController {
         return ResponseEntity.ok(adminEventService.getEventApply(eventId,cond, start, limit));
     }
 
+    @Operation(summary = "이벤트 신청자 수 조회", description = "관리자 이벤트 상세의 신청자 패널에서 전체 신청자 수를 조회합니다.")
     @GetMapping("apply-list/count/{eventId}")
     public ResponseEntity<Count> getEventApplyCount(@PathVariable long eventId){
         return ResponseEntity.ok(adminEventService.getEventApplyCount(eventId));

--- a/run/src/main/java/com/guide/run/admin/controller/AdminPartnerController.java
+++ b/run/src/main/java/com/guide/run/admin/controller/AdminPartnerController.java
@@ -4,6 +4,9 @@ import com.guide.run.admin.dto.response.partner.AdminPartnerList;
 import com.guide.run.admin.dto.response.partner.PartnerTypeResponse;
 import com.guide.run.admin.service.AdminPartnerService;
 import com.guide.run.event.entity.dto.response.get.Count;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,9 +14,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
+@Tag(name = "Admin Partner", description = "관리자 사용자 상세의 파트너 이력/통계 API")
+@SecurityRequirement(name = "bearerAuth")
 public class AdminPartnerController {
     private final AdminPartnerService adminPartnerService;
 
+    @Operation(summary = "사용자 파트너 이력 조회", description = "관리자 사용자 상세의 파트너 탭에서 이벤트 종류별 파트너 목록을 조회합니다.")
     @GetMapping("/partner-list/{userId}")
     public ResponseEntity<AdminPartnerList> getPartnerList(@PathVariable String userId,
                                                               @RequestParam String kind,
@@ -25,12 +31,14 @@ public class AdminPartnerController {
 
         return ResponseEntity.ok(response);
     }
+    @Operation(summary = "사용자 파트너 이력 개수 조회", description = "관리자 사용자 상세의 파트너 탭에서 이벤트 종류별 파트너 수를 조회합니다.")
     @GetMapping("/partner-list/count/{userId}")
     public ResponseEntity<Count> getPartnerListCount(@PathVariable String userId,
                                                      @RequestParam String kind){
         return ResponseEntity.ok(adminPartnerService.getPartnerCount(userId, kind));
     }
 
+    @Operation(summary = "사용자 파트너 유형별 통계 조회", description = "관리자 사용자 상세의 파트너 탭에서 훈련/대회 기준 파트너 통계를 조회합니다.")
     @GetMapping("/partner-type/count/{userId}")
     public ResponseEntity<PartnerTypeResponse> getPartnerType(@PathVariable String userId){
         return ResponseEntity.ok(adminPartnerService.getPartnerType(userId));

--- a/run/src/main/java/com/guide/run/admin/controller/AdminSearchController.java
+++ b/run/src/main/java/com/guide/run/admin/controller/AdminSearchController.java
@@ -16,6 +16,9 @@ import com.guide.run.admin.service.AdminPartnerService;
 import com.guide.run.admin.service.AdminUserService;
 import com.guide.run.admin.service.AdminWithdrawalService;
 import com.guide.run.event.entity.dto.response.get.Count;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +28,8 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/search")
+@Tag(name = "Admin Search", description = "관리자 검색형 목록 조회 API")
+@SecurityRequirement(name = "bearerAuth")
 public class AdminSearchController {
     private final AdminUserService adminUserService;
     private final AdminEventService adminEventService;
@@ -32,6 +37,7 @@ public class AdminSearchController {
     private final AdminWithdrawalService adminWithdrawalService;
 
     //전체 검색
+    @Operation(summary = "관리자 통합 검색", description = "사용자와 이벤트를 동시에 검색하는 관리자 통합 검색 API입니다.")
     @GetMapping("/all")
     public ResponseEntity<AdminSearchList> searchAll(@RequestParam(defaultValue = "") String text,
                                                      @RequestParam(defaultValue = "0") int start,
@@ -74,6 +80,7 @@ public class AdminSearchController {
         return ResponseEntity.ok(response);
     }
     //회원 검색
+    @Operation(summary = "관리자 회원 검색 목록 조회", description = "관리자 회원 목록 화면에서 검색어와 필터로 회원 목록을 조회합니다.")
     @GetMapping("/user")
     public ResponseEntity<AdminUserList> searchUser(@RequestParam(defaultValue = "") String text,
                                                     @RequestParam(defaultValue = "0") int start,
@@ -97,6 +104,7 @@ public class AdminSearchController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "관리자 회원 검색 개수 조회", description = "관리자 회원 목록 화면에서 검색 결과 개수를 조회합니다.")
     @GetMapping("/user/count")
     public ResponseEntity<Count> searchUserCount(@RequestParam(defaultValue = "") String text){
         Count response = adminUserService.searchUserCount(text);
@@ -104,6 +112,7 @@ public class AdminSearchController {
     }
 
     //이벤트 검색
+    @Operation(summary = "관리자 이벤트 검색 목록 조회", description = "관리자 이벤트 목록 화면에서 검색어와 필터로 이벤트 목록을 조회합니다.")
     @GetMapping("/event")
     public ResponseEntity<AdminEventList> searchEvent(@RequestParam(defaultValue = "") String text,
                                                       @RequestParam(defaultValue = "0") int start,
@@ -124,12 +133,14 @@ public class AdminSearchController {
         return ResponseEntity.ok(eventList);
     }
 
+    @Operation(summary = "관리자 이벤트 검색 개수 조회", description = "관리자 이벤트 목록 화면에서 검색 결과 개수를 조회합니다.")
     @GetMapping("/event/count")
     public ResponseEntity<Count> searchEventCount(@RequestParam(defaultValue = "") String text){
         return ResponseEntity.ok(adminEventService.searchAllEventCount(text));
     }
 
     //탈퇴한 회원 검색
+    @Operation(summary = "관리자 탈퇴 회원 검색 목록 조회", description = "관리자 탈퇴 회원 화면에서 검색어와 필터로 탈퇴 회원 목록을 조회합니다.")
     @GetMapping("/withdrawal-list")
     public ResponseEntity<WithdrawalList> searchWithDrawal(@RequestParam(defaultValue = "") String text,
                                                            @RequestParam(defaultValue = "0") int start,
@@ -152,12 +163,14 @@ public class AdminSearchController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "관리자 탈퇴 회원 검색 개수 조회", description = "관리자 탈퇴 회원 화면에서 검색 결과 개수를 조회합니다.")
     @GetMapping("/withdrawal-list/count")
     public ResponseEntity<Count> searchWithDrawalCount(@RequestParam(defaultValue = "") String text){
         return ResponseEntity.ok(adminWithdrawalService.searchWithdrawalCount(text));
     }
 
     //파트너 검색
+    @Operation(summary = "관리자 파트너 검색 목록 조회", description = "관리자 사용자 상세의 파트너 탭에서 검색어 기준 파트너 목록을 조회합니다.")
     @GetMapping("/partner-list/{userId}")
     public ResponseEntity<AdminPartnerList> searchPartner(@PathVariable String userId,
                                                           @RequestParam(defaultValue = "") String text,
@@ -169,6 +182,7 @@ public class AdminSearchController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "관리자 파트너 검색 개수 조회", description = "관리자 사용자 상세의 파트너 탭에서 검색 결과 개수를 조회합니다.")
     @GetMapping("/partner-list/count/{userId}")
     public ResponseEntity<Count> searchPartnerCount(@PathVariable String userId,
                                                     @RequestParam(defaultValue = "") String text){
@@ -176,6 +190,7 @@ public class AdminSearchController {
     }
 
     //이벤트 히스토리 검색
+    @Operation(summary = "관리자 사용자 이벤트 이력 검색 목록 조회", description = "관리자 사용자 상세의 이벤트 탭에서 검색어 기준 이력 목록을 조회합니다.")
     @GetMapping("/event-list/{userId}")
     public ResponseEntity<AdminEventHistoryList>searchEventHistory(@PathVariable String userId,
                                                                    @RequestParam(defaultValue = "") String text,
@@ -189,6 +204,7 @@ public class AdminSearchController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "관리자 사용자 이벤트 이력 검색 개수 조회", description = "관리자 사용자 상세의 이벤트 탭에서 검색 결과 개수를 조회합니다.")
     @GetMapping("/event-list/count/{userId}")
     public ResponseEntity<Count> searchEventHistoryCount(@PathVariable String userId,
                                                          @RequestParam(defaultValue = "") String text){

--- a/run/src/main/java/com/guide/run/admin/controller/AdminUserController.java
+++ b/run/src/main/java/com/guide/run/admin/controller/AdminUserController.java
@@ -9,6 +9,9 @@ import com.guide.run.admin.service.AdminUserService;
 
 import com.guide.run.event.entity.dto.response.get.Count;
 import com.guide.run.global.jwt.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,11 +20,14 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
+@Tag(name = "Admin User", description = "관리자 회원 목록, 검색, 승인 관련 API")
+@SecurityRequirement(name = "bearerAuth")
 public class AdminUserController {
     private final AdminUserService adminUserService;
     private final JwtProvider jwtProvider;
 
     //전체 회원
+    @Operation(summary = "관리자 회원 목록 조회", description = "관리자 회원 목록 화면에서 필터와 페이지네이션 조건에 맞는 회원 목록을 조회합니다.")
     @GetMapping("/user-list")
     public ResponseEntity<AdminUserList> getUserList(@RequestParam int start,
                                                      @RequestParam int limit,
@@ -45,11 +51,13 @@ public class AdminUserController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "관리자 회원 목록 개수 조회", description = "관리자 회원 목록 화면의 전체 건수를 조회합니다.")
     @GetMapping("/user-list/count")
     public ResponseEntity<Count> getUserListCount(){
         Count response = adminUserService.getUserListCount();
         return ResponseEntity.ok().body(response);
     }
+    @Operation(summary = "최근 가입 회원 조회", description = "관리자 메인 화면에서 최근 가입 회원 목록을 조회합니다.")
     @GetMapping("/new-user")
     public ResponseEntity<NewUserList> getNewUserList(@RequestParam int start,
                                                       @RequestParam int limit,
@@ -62,18 +70,21 @@ public class AdminUserController {
     }
 
     //단일 회원
+    @Operation(summary = "VI 신청 상세 조회", description = "관리자 사용자 상세에서 VI 신청 상세를 조회합니다.")
     @GetMapping("/apply/vi/{userId}")
     public ResponseEntity<ViApplyResponse> getApplyVi(@PathVariable String userId){
         ViApplyResponse response = adminUserService.getApplyVi(userId);
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "Guide 신청 상세 조회", description = "관리자 사용자 상세에서 Guide 신청 상세를 조회합니다.")
     @GetMapping("/apply/guide/{userId}")
     public ResponseEntity<GuideApplyResponse> getApplyGuide(@PathVariable String userId){
         GuideApplyResponse response = adminUserService.getApplyGuide(userId);
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "회원 승인/반려 처리", description = "관리자 사용자 상세 다이얼로그에서 회원 승인 상태를 변경합니다.")
     @PostMapping("/approval-user/{userId}")
     public ResponseEntity<UserApprovalResponse> approveUser(@PathVariable String userId, @RequestBody ApproveRequest request){
         UserApprovalResponse response = adminUserService.approveUser(userId, request);

--- a/run/src/main/java/com/guide/run/admin/controller/AdminWithdrawalController.java
+++ b/run/src/main/java/com/guide/run/admin/controller/AdminWithdrawalController.java
@@ -4,6 +4,9 @@ import com.guide.run.admin.dto.condition.WithdrawalSortCond;
 import com.guide.run.admin.dto.response.user.WithdrawalList;
 import com.guide.run.admin.service.AdminWithdrawalService;
 import com.guide.run.event.entity.dto.response.get.Count;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,9 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
+@Tag(name = "Admin Withdrawal", description = "관리자 탈퇴 회원 목록/통계 API")
+@SecurityRequirement(name = "bearerAuth")
 public class AdminWithdrawalController {
     private final AdminWithdrawalService adminWithDrawalService;
 
+    @Operation(summary = "탈퇴 회원 목록 조회", description = "관리자 탈퇴 회원 화면에서 필터와 페이지네이션 조건에 맞는 탈퇴 회원 목록을 조회합니다.")
     @GetMapping("/withdrawal-list")
     public ResponseEntity<WithdrawalList> getWithdrawalList(@RequestParam(defaultValue = "0") int start,
                                                             @RequestParam(defaultValue = "10") int limit,
@@ -38,6 +44,7 @@ public class AdminWithdrawalController {
 
     }
 
+    @Operation(summary = "탈퇴 회원 개수 조회", description = "관리자 탈퇴 회원 화면의 전체 건수를 조회합니다.")
     @GetMapping("/withdrawal-list/count")
     public ResponseEntity<Count> getWithdrawalCount(){
         return ResponseEntity.ok(adminWithDrawalService.getWithdrawalCount());

--- a/run/src/main/java/com/guide/run/admin/dto/EventDto.java
+++ b/run/src/main/java/com/guide/run/admin/dto/EventDto.java
@@ -1,6 +1,7 @@
 package com.guide.run.admin.dto;
 
 import com.guide.run.event.entity.type.EventRecruitStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,8 +9,11 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 @Getter
+@Schema(description = "관리자 이벤트 목록 항목")
 public class EventDto {
+    @Schema(description = "이벤트 ID", example = "1023")
     private Long eventId;
+    @Schema(description = "이벤트 이름", example = "상계천 천천히 달리기")
     private String name;
     private String smallDate;
     private String startTime;

--- a/run/src/main/java/com/guide/run/admin/dto/response/event/AdminEventList.java
+++ b/run/src/main/java/com/guide/run/admin/dto/response/event/AdminEventList.java
@@ -1,6 +1,7 @@
 package com.guide.run.admin.dto.response.event;
 
 import com.guide.run.admin.dto.EventDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,8 @@ import java.util.List;
 @Builder
 @Getter
 @AllArgsConstructor
+@Schema(description = "관리자 이벤트 목록 응답")
 public class AdminEventList {
+    @Schema(description = "이벤트 목록")
     private List<EventDto> items;
 }

--- a/run/src/main/java/com/guide/run/admin/dto/response/user/AdminUserList.java
+++ b/run/src/main/java/com/guide/run/admin/dto/response/user/AdminUserList.java
@@ -1,5 +1,6 @@
 package com.guide.run.admin.dto.response.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,8 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @Builder
+@Schema(description = "관리자 회원 목록 응답")
 public class AdminUserList {
+    @Schema(description = "회원 목록")
     private List<UserItem> items;
 }

--- a/run/src/main/java/com/guide/run/admin/dto/response/user/UserItem.java
+++ b/run/src/main/java/com/guide/run/admin/dto/response/user/UserItem.java
@@ -2,6 +2,7 @@ package com.guide.run.admin.dto.response.user;
 
 import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.entity.type.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,12 +12,17 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "관리자 회원 목록 항목")
 public class UserItem {
+    @Schema(description = "공개 사용자 ID", example = "guide_102")
     private String userId;
     private String img;
+    @Schema(description = "권한", example = "USER")
     private String role;
     private int age;
+    @Schema(description = "사용자 유형", example = "GUIDE")
     private String type;
+    @Schema(description = "이름", example = "홍길동")
     private String name;
     private String team;
     private String gender;

--- a/run/src/main/java/com/guide/run/event/controller/EventAttendanceController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventAttendanceController.java
@@ -5,6 +5,9 @@ import com.guide.run.event.entity.dto.response.attend.AttendCount;
 import com.guide.run.event.entity.dto.response.attend.ParticipationCount;
 import com.guide.run.event.entity.dto.response.attend.ParticipationInfos;
 import com.guide.run.event.service.EventAttendService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,8 +16,11 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")
+@Tag(name = "Event Attendance", description = "이벤트 출석 체크와 신청 현황 조회 API")
+@SecurityRequirement(name = "bearerAuth")
 public class EventAttendanceController {
     private final EventAttendService eventAttendService;
+    @Operation(summary = "출석 체크", description = "이벤트 상세의 출석 체크 모드에서 특정 신청자를 출석 처리합니다.")
     @PostMapping("/{eventId}/attend/{userId}")
     public ResponseEntity<String> requestAttend(@PathVariable("eventId") Long eventId,
                                                 @PathVariable("userId") String userId,
@@ -22,16 +28,19 @@ public class EventAttendanceController {
         eventAttendService.requestAttend(eventId,userId);
         return ResponseEntity.status(200).body("200 ok");
     }
+    @Operation(summary = "출석 현황 개수 조회", description = "출석 체크 화면에서 출석/미출석 인원 수를 조회합니다.")
     @GetMapping("/{eventId}/attend/count")
     public ResponseEntity<AttendCount> getAttendCount(@PathVariable("eventId") Long eventId,
                                                       HttpServletRequest request){
         return ResponseEntity.ok().body(eventAttendService.getAttendCount(eventId));
     }
+    @Operation(summary = "이벤트 신청 현황 개수 조회", description = "이벤트 상세의 출석/매칭 패널에서 총 신청자 수와 VI/Guide 수를 조회합니다.")
     @GetMapping("/{eventId}/forms/count")
     public ResponseEntity<ParticipationCount> getParticipationCount(@PathVariable("eventId") Long eventId,
                                                                     HttpServletRequest request){
         return ResponseEntity.ok().body(eventAttendService.getParticipationCount(eventId));
     }
+    @Operation(summary = "이벤트 신청 현황 목록 조회", description = "이벤트 상세의 출석 패널에서 출석 완료/미완료 신청자 목록을 조회합니다.")
     @GetMapping("/{eventId}/forms")
     public ResponseEntity<ParticipationInfos> getParticipationInfos(@PathVariable("eventId") Long eventId,
                                                                     HttpServletRequest request){

--- a/run/src/main/java/com/guide/run/event/controller/EventCalenderController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventCalenderController.java
@@ -7,6 +7,10 @@ import com.guide.run.global.exception.event.logic.NotValidDayException;
 import com.guide.run.global.exception.event.logic.NotValidMonthException;
 import com.guide.run.global.exception.event.logic.NotValidYearException;
 import com.guide.run.global.jwt.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -17,12 +21,15 @@ import java.time.YearMonth;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event/calendar")
+@Tag(name = "Event", description = "이벤트 캘린더 조회 API")
+@SecurityRequirement(name = "bearerAuth")
 public class EventCalenderController {
     private final JwtProvider jwtProvider;
     private final EventCalenderService eventCalenderService;
+    @Operation(summary = "월간 이벤트 캘린더 조회", description = "이벤트 캘린더 화면에서 특정 월의 일자별 이벤트 존재 여부를 조회합니다.")
     @GetMapping("")
-    public MyEventsOfMonthOfCalender getMyEventsOfMonth(@RequestParam("year")int year,
-                                                        @RequestParam("month") int month,
+    public MyEventsOfMonthOfCalender getMyEventsOfMonth(@Parameter(description = "조회 연도", example = "2026") @RequestParam("year")int year,
+                                                        @Parameter(description = "조회 월", example = "3") @RequestParam("month") int month,
                                                         HttpServletRequest request){
         if(year<0)
             throw new NotValidYearException();
@@ -31,10 +38,11 @@ public class EventCalenderController {
         String userId = jwtProvider.extractUserId(request);
         return eventCalenderService.getMyEventsOfMonth(year,month,userId);
     }
+    @Operation(summary = "일간 이벤트 캘린더 상세 조회", description = "이벤트 캘린더 화면에서 특정 날짜에 해당하는 상세 이벤트 목록을 조회합니다.")
     @GetMapping("/detail")
-    public MyEventsOfDayOfCalendar getMyEventsOfDay(@RequestParam("year")int year,
-                                                    @RequestParam("month") int month,
-                                                    @RequestParam("day") int day,
+    public MyEventsOfDayOfCalendar getMyEventsOfDay(@Parameter(description = "조회 연도", example = "2026") @RequestParam("year")int year,
+                                                    @Parameter(description = "조회 월", example = "3") @RequestParam("month") int month,
+                                                    @Parameter(description = "조회 일", example = "20") @RequestParam("day") int day,
                                                     HttpServletRequest request){
         if(year<0)
             throw new NotValidYearException();

--- a/run/src/main/java/com/guide/run/event/controller/EventCommentController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventCommentController.java
@@ -7,6 +7,10 @@ import com.guide.run.event.entity.dto.response.comments.response.CommentsGetResp
 import com.guide.run.event.entity.dto.response.get.Count;
 import com.guide.run.event.service.EventCommentService;
 import com.guide.run.global.jwt.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,9 +19,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")
+@Tag(name = "Event Comment", description = "이벤트 댓글 조회/생성/수정/삭제 API")
+@SecurityRequirement(name = "bearerAuth")
 public class EventCommentController {
     private final JwtProvider jwtProvider;
     private final EventCommentService eventCommentService;
+    @Operation(summary = "이벤트 댓글 작성", description = "이벤트 상세 화면의 댓글 섹션에서 댓글을 작성합니다.")
     @PostMapping("/{eventId}/comments")
     public ResponseEntity<CommentsCreatedResponse> createComment(@PathVariable Long eventId,
                                                                  HttpServletRequest request,
@@ -26,6 +33,7 @@ public class EventCommentController {
         return ResponseEntity.status(200).body(CommentsCreatedResponse.builder()
                 .commentId(eventCommentService.createComment(eventId,userId,eventCommentCreateRequest)).build());
     }
+    @Operation(summary = "이벤트 댓글 삭제", description = "이벤트 상세 화면의 댓글 항목에서 댓글을 삭제합니다.")
     @DeleteMapping("/{eventId}/{commentId}")
     public ResponseEntity<CommentsDeletedResponse> deleteComment(@PathVariable Long eventId,
                                                                  @PathVariable Long commentId,
@@ -34,6 +42,7 @@ public class EventCommentController {
         return ResponseEntity.status(200).body(CommentsDeletedResponse.builder()
                 .commentId(eventCommentService.deleteComment(eventId,commentId,userId)).build());
     }
+    @Operation(summary = "이벤트 댓글 수정", description = "이벤트 상세 화면의 댓글 항목에서 댓글 내용을 수정합니다.")
     @PatchMapping("/{eventId}/{commentId}")
     public ResponseEntity<CommentsCreatedResponse> patchComment(@PathVariable Long eventId,
                                                                  @PathVariable Long commentId,
@@ -43,15 +52,19 @@ public class EventCommentController {
         return ResponseEntity.status(200).body(CommentsCreatedResponse.builder()
                 .commentId(eventCommentService.patchComment(eventId,commentId,eventCommentCreateRequest,userId)).build());
     }
+    @Operation(summary = "이벤트 댓글 목록 조회", description = "이벤트 상세 화면의 댓글 섹션에서 페이지네이션 댓글 목록을 조회합니다.")
     @GetMapping("/{eventId}/comments")
     public ResponseEntity<CommentsGetResponse> getComments(@PathVariable Long eventId,
+                                                           @Parameter(description = "조회 개수", example = "4")
                                                            @RequestParam int limit,
+                                                           @Parameter(description = "페이지 시작 offset", example = "0")
                                                            @RequestParam int start,
                                                            HttpServletRequest request){
         String userId = jwtProvider.extractUserId(request);
         return ResponseEntity.status(200).body(CommentsGetResponse.builder()
                 .comments(eventCommentService.getComments(eventId,limit,start,userId)).build());
     }
+    @Operation(summary = "이벤트 댓글 개수 조회", description = "이벤트 상세 화면에서 댓글 총 개수를 조회합니다.")
     @GetMapping("/{eventId}/comments/count")
     public ResponseEntity<Count> getCommentsCount(@PathVariable Long eventId,
                                                   HttpServletRequest request){

--- a/run/src/main/java/com/guide/run/event/controller/EventController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventController.java
@@ -9,6 +9,9 @@ import com.guide.run.event.entity.dto.response.get.MyEventDdayResponse;
 import com.guide.run.event.service.EventService;
 import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.global.scheduler.SchedulerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,12 +21,15 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")
+@Tag(name = "Event", description = "이벤트 생성, 수정, 삭제와 상세 조회 API")
+@SecurityRequirement(name = "bearerAuth")
 public class EventController {
     private final JwtProvider jwtProvider;
     private final EventService eventService;
 
     private final SchedulerService schedulerService;
 
+    @Operation(summary = "이벤트 생성", description = "신규 이벤트 생성 화면에서 이벤트를 등록합니다. 생성 직후 스케줄러 등록이 함께 수행됩니다.")
     @PostMapping
     public ResponseEntity<EventCreatedResponse> eventCreate(@RequestBody EventCreateRequest request, HttpServletRequest httpServletRequest){
         String privateId = jwtProvider.extractUserId(httpServletRequest);
@@ -32,6 +38,7 @@ public class EventController {
         schedulerService.createSchedule(eventCreatedResponse.getEventId());
         return ResponseEntity.status(HttpStatus.CREATED).body(eventCreatedResponse);
     }
+    @Operation(summary = "이벤트 수정", description = "이벤트 수정 화면에서 기존 이벤트를 수정합니다. 수정 후 스케줄러 정보도 함께 갱신됩니다.")
     @PatchMapping("/{eventId}")
     public ResponseEntity<EventUpdatedResponse> eventUpdate(@PathVariable Long eventId,@RequestBody EventCreateRequest request, HttpServletRequest httpServletRequest){
         String priavateId = jwtProvider.extractUserId(httpServletRequest);
@@ -41,6 +48,7 @@ public class EventController {
         return ResponseEntity.status(HttpStatus.OK).body(eventUpdatedResponse);
     }
 
+    @Operation(summary = "이벤트 조기 마감", description = "이벤트 상세/수정 화면에서 모집을 조기 종료합니다.")
     @PatchMapping("/close/{eventId}")
     public ResponseEntity<String> eventClose(@PathVariable Long eventId, HttpServletRequest request){
         String privateId = jwtProvider.extractUserId(request);
@@ -49,6 +57,7 @@ public class EventController {
         return ResponseEntity.status(HttpStatus.OK).body("");
     }
 
+    @Operation(summary = "이벤트 삭제", description = "관리자 이벤트 다이얼로그 또는 개설자 화면에서 이벤트를 삭제합니다.")
     @DeleteMapping("/{eventId}")
     public ResponseEntity<?> eventDelete(@PathVariable Long eventId,HttpServletRequest request){
         String userId = jwtProvider.extractUserId(request);
@@ -58,18 +67,21 @@ public class EventController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @Operation(summary = "이벤트 팝업 정보 조회", description = "이벤트 모달/팝업에서 사용하는 축약 이벤트 정보를 조회합니다.")
     @GetMapping("/pop/{eventId}")
     public ResponseEntity<EventPopUpResponse> eventPopUp(@PathVariable Long eventId, HttpServletRequest request){
         String privateId = jwtProvider.extractUserId(request);
         EventPopUpResponse response = eventService.eventPopUp(eventId, privateId);
         return ResponseEntity.ok().body(response);
     }
+    @Operation(summary = "다가오는 내 이벤트 D-day 조회", description = "메인 화면 상단에서 사용할 D-day 목록을 조회합니다.")
     @GetMapping("/dday")
     public ResponseEntity<MyEventDdayResponse> getMyEventDday(HttpServletRequest request){
         String privateId = jwtProvider.extractUserId(request);
         return ResponseEntity.ok().
                 body(eventService.getMyEventDday(privateId));
     }
+    @Operation(summary = "이벤트 상세 조회", description = "이벤트 상세 화면과 관리자 이벤트 다이얼로그에서 사용하는 전체 이벤트 상세 정보를 조회합니다.")
     @GetMapping("/{eventId}")
     public ResponseEntity<DetailEvent> getDetailEvent(@PathVariable("eventId")Long eventId,
                                                       HttpServletRequest request){

--- a/run/src/main/java/com/guide/run/event/controller/EventFormController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventFormController.java
@@ -6,6 +6,9 @@ import com.guide.run.event.entity.dto.response.form.GetAllForms;
 import com.guide.run.event.entity.dto.response.form.GetForm;
 import com.guide.run.event.service.EventFormService;
 import com.guide.run.global.jwt.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,9 +17,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")
+@Tag(name = "Event Application", description = "이벤트 신청서 조회/생성/수정/삭제 API")
+@SecurityRequirement(name = "bearerAuth")
 public class EventFormController {
     private final EventFormService eventFormService;
     private final JwtProvider jwtProvider;
+    @Operation(summary = "이벤트 신청서 생성", description = "이벤트 신청 화면에서 현재 로그인 사용자의 신청서를 생성합니다.")
     @PostMapping("/{eventId}/form")
     public ResponseEntity<CreatedForm> createForm(@RequestBody CreateEventForm createForm,
                                                   @PathVariable("eventId") Long eventId,
@@ -27,6 +33,7 @@ public class EventFormController {
                 .build());
     }
 
+    @Operation(summary = "이벤트 신청서 수정", description = "이벤트 신청 수정 화면에서 기존 신청서를 수정합니다.")
     @PatchMapping("/{eventId}/form")
     public ResponseEntity<CreatedForm> patchForm(@RequestBody CreateEventForm createForm,
                                                   @PathVariable("eventId") Long eventId,
@@ -36,17 +43,20 @@ public class EventFormController {
                 .requestId(eventFormService.patchForm(createForm,eventId,userId))
                 .build());
     }
+    @Operation(summary = "특정 사용자 이벤트 신청서 조회", description = "신청 상세 툴팁과 신청 수정 화면에서 특정 사용자의 이벤트 신청서를 조회합니다.")
     @GetMapping("/{eventId}/form/{userId}")
     public ResponseEntity<GetForm> getForm(@PathVariable("eventId") Long eventId,
                                            @PathVariable("userId") String userId,
                                            HttpServletRequest request){
         return ResponseEntity.ok().body(eventFormService.getForm(eventId,userId));
     }
+    @Operation(summary = "이벤트 전체 신청자 상세 조회", description = "이벤트 상세 화면의 신청자 패널에서 VI/Guide 신청자 목록을 함께 조회합니다.")
     @GetMapping("/{eventId}/forms/all")
     public ResponseEntity<GetAllForms> getAllForms(@PathVariable("eventId") Long eventId, HttpServletRequest request){
         String privateId = jwtProvider.extractUserId(request);
         return ResponseEntity.ok().body(eventFormService.getAllForms(eventId,privateId));
     }
+    @Operation(summary = "내 이벤트 신청서 삭제", description = "이벤트 상세 또는 신청 상세 화면에서 현재 로그인 사용자의 신청서를 취소합니다.")
     @DeleteMapping("/{eventId}/form")
     public ResponseEntity<String> deleteForm(@PathVariable("eventId") Long eventId,
                                              HttpServletRequest request){

--- a/run/src/main/java/com/guide/run/event/controller/EventGetController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventGetController.java
@@ -13,6 +13,10 @@ import com.guide.run.global.exception.event.logic.NotValidSortException;
 import com.guide.run.global.exception.event.logic.NotValidTypeException;
 import com.guide.run.global.exception.event.logic.NotValidYearException;
 import com.guide.run.global.jwt.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,13 +31,16 @@ import static com.guide.run.event.entity.type.EventType.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")
+@Tag(name = "Event", description = "이벤트 목록, 나의 이벤트, 카운트 조회 API")
+@SecurityRequirement(name = "bearerAuth")
 public class EventGetController {
     private final JwtProvider jwtProvider;
     private final EventGetService eventGetService;
 
+    @Operation(summary = "나의 이벤트 목록 조회", description = "나의 이벤트 화면에서 예정/종료 이벤트를 연도별로 조회합니다.")
     @GetMapping("/my")
-    public ResponseEntity<MyEventResponse> getMyEventList(@RequestParam("sort") String sort
-    , @RequestParam("year") int year, HttpServletRequest request)
+    public ResponseEntity<MyEventResponse> getMyEventList(@Parameter(description = "정렬 구분", example = "UPCOMING") @RequestParam("sort") String sort
+    , @Parameter(description = "조회 연도", example = "2026") @RequestParam("year") int year, HttpServletRequest request)
     {
         if(year<0){
             throw new NotValidYearException();
@@ -42,10 +49,11 @@ public class EventGetController {
         MyEventResponse myEvent = eventGetService.getMyEvent(sort,year,userId);
         return ResponseEntity.status(200).body(myEvent);
     }
+    @Operation(summary = "전체 이벤트 개수 조회", description = "전체 이벤트 탭에서 선택한 필터 조건에 맞는 총 이벤트 개수를 조회합니다.")
     @GetMapping("/all/count")
-    public ResponseEntity<Count> getAllEventListCount(@RequestParam("sort") String sort,
-                                                      @RequestParam("type") EventType type,
-                                                      @RequestParam("kind") EventRecruitStatus kind,
+    public ResponseEntity<Count> getAllEventListCount(@Parameter(description = "탭 구분", example = "UPCOMING") @RequestParam("sort") String sort,
+                                                      @Parameter(description = "이벤트 유형 필터", example = "TRAINING") @RequestParam("type") EventType type,
+                                                      @Parameter(description = "모집 상태 필터", example = "RECRUIT_OPEN") @RequestParam("kind") EventRecruitStatus kind,
                                                       @RequestParam(value = "cityName", required = false) CityName cityName,
                                                       HttpServletRequest request){
         if(sort.equals("UPCOMING") || sort.equals("END") || sort.equals("MY")){}
@@ -60,12 +68,15 @@ public class EventGetController {
                 body(Count.builder().count(eventGetService.getAllEventListCount(sort,type,kind,userId,cityName)).build());
     }
 
+    @Operation(summary = "전체 이벤트 목록 조회", description = "전체 이벤트 탭에서 선택한 필터와 페이지네이션 조건에 맞는 이벤트 목록을 조회합니다.")
     @GetMapping("/all")
-    public ResponseEntity<AllEventResponse> getAllEventList(@RequestParam("sort") String sort,
-                                                            @RequestParam("type") EventType type,
-                                                            @RequestParam("kind") EventRecruitStatus kind,
+    public ResponseEntity<AllEventResponse> getAllEventList(@Parameter(description = "탭 구분", example = "UPCOMING") @RequestParam("sort") String sort,
+                                                            @Parameter(description = "이벤트 유형 필터", example = "TRAINING") @RequestParam("type") EventType type,
+                                                            @Parameter(description = "모집 상태 필터", example = "RECRUIT_OPEN") @RequestParam("kind") EventRecruitStatus kind,
                                                             @RequestParam(value = "cityName", required = false) CityName cityName,
+                                                            @Parameter(description = "페이지 크기", example = "6")
                                                             @RequestParam("limit") int limit,
+                                                            @Parameter(description = "페이지 시작 offset", example = "0")
                                                             @RequestParam("start") int start,
                                                             HttpServletRequest request){
         if(sort.equals("UPCOMING") || sort.equals("END") || sort.equals("MY")){}

--- a/run/src/main/java/com/guide/run/event/controller/EventLikeController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventLikeController.java
@@ -4,6 +4,9 @@ import com.guide.run.event.entity.dto.response.LikeCountResponse;
 import com.guide.run.event.entity.dto.response.LikeResponse;
 import com.guide.run.event.service.EventLikeService;
 import com.guide.run.global.jwt.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,26 +15,32 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")
+@Tag(name = "Event Like", description = "이벤트와 댓글 좋아요 API")
+@SecurityRequirement(name = "bearerAuth")
 public class EventLikeController {
     private final JwtProvider jwtProvider;
     private final EventLikeService eventLikeService;
+    @Operation(summary = "댓글 좋아요 토글", description = "이벤트 상세 댓글 목록에서 특정 댓글의 좋아요 상태를 토글합니다.")
     @PostMapping("/comment/{commentId}/likes")
     public ResponseEntity<LikeResponse> pressCommentLike(@PathVariable Long commentId, HttpServletRequest request){
         String privateId = jwtProvider.extractUserId(request);
         return ResponseEntity.ok().body(eventLikeService.pressCommentLike(commentId,privateId));
     }
 
+    @Operation(summary = "댓글 좋아요 상태 조회", description = "이벤트 상세 댓글 목록에서 좋아요 수와 현재 사용자의 좋아요 여부를 조회합니다.")
     @GetMapping("/comment/{commentId}/likes/count")
     public ResponseEntity<LikeCountResponse> getCommentLikeCount(@PathVariable Long commentId, HttpServletRequest request){
         String privateId = jwtProvider.extractUserId(request);
         return ResponseEntity.ok().body(eventLikeService.getCommentLikeCount(commentId,privateId));
     }
 
+    @Operation(summary = "이벤트 좋아요 토글", description = "이벤트 상세 화면에서 이벤트 좋아요 상태를 토글합니다.")
     @PostMapping("/{eventId}/likes")
     public ResponseEntity<LikeResponse> pressEventLike(@PathVariable Long eventId, HttpServletRequest request){
         String privateId = jwtProvider.extractUserId(request);
         return ResponseEntity.ok().body(eventLikeService.pressEventLike(eventId,privateId));
     }
+    @Operation(summary = "이벤트 좋아요 상태 조회", description = "이벤트 상세 화면에서 좋아요 수와 현재 사용자의 좋아요 여부를 조회합니다.")
     @GetMapping("/{eventId}/likes/count")
     public ResponseEntity<LikeCountResponse> getEventLikeCount(@PathVariable Long eventId, HttpServletRequest request){
         String privateId = jwtProvider.extractUserId(request);

--- a/run/src/main/java/com/guide/run/event/controller/EventMatchingController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventMatchingController.java
@@ -3,6 +3,9 @@ package com.guide.run.event.controller;
 import com.guide.run.event.entity.dto.response.match.*;
 import com.guide.run.event.service.EventMatchingService;
 import com.guide.run.global.jwt.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,10 +17,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")
+@Tag(name = "Event Matching", description = "이벤트 신청자 매칭 조회/실행 API")
+@SecurityRequirement(name = "bearerAuth")
 public class EventMatchingController {
     private final JwtProvider jwtProvider;
     private final EventMatchingService eventMatchingService;
 
+    @Operation(summary = "수동 매칭 생성", description = "이벤트 상세의 매칭 패널에서 VI와 Guide를 수동으로 매칭합니다.")
     @PostMapping("{eventId}/match/{viId}/{userId}")
     public ResponseEntity<String> matchUser(@PathVariable("eventId") Long eventId,
                                             @PathVariable("viId") String viId,
@@ -27,6 +33,7 @@ public class EventMatchingController {
         eventMatchingService.matchUser(eventId,viId,userId);
         return ResponseEntity.ok().body("200 ok");
     }
+    @Operation(summary = "매칭 취소", description = "이벤트 상세의 매칭 패널에서 특정 사용자 매칭을 해제합니다.")
     @DeleteMapping("{eventId}/match/{userId}")
     public ResponseEntity<String> deleteUser(@PathVariable("eventId") Long eventId,
                                             @PathVariable("userId") String userId,
@@ -35,12 +42,14 @@ public class EventMatchingController {
         eventMatchingService.deleteMatchUser(eventId,userId);
         return ResponseEntity.ok().body("200 ok");
     }
+    @Operation(summary = "미매칭 사용자 수 조회", description = "이벤트 상세의 매칭 패널에서 미매칭 VI/Guide 수를 조회합니다.")
     @GetMapping("{eventId}/match/not/count")
     public ResponseEntity<UserTypeCount> getUserTypeCount(@PathVariable("eventId") Long eventId,
                                                           HttpServletRequest request){
         jwtProvider.extractUserId(request);
         return ResponseEntity.ok().body(eventMatchingService.getUserTypeCount(eventId));
     }
+    @Operation(summary = "미매칭 사용자 목록 조회", description = "이벤트 상세의 매칭 패널에서 아직 매칭되지 않은 신청자 목록을 조회합니다.")
     @GetMapping("{eventId}/match/list")
     public ResponseEntity<NotMatchList> getNotMatchList(@PathVariable("eventId") Long eventId,
                                                          HttpServletRequest request){
@@ -48,6 +57,7 @@ public class EventMatchingController {
         return ResponseEntity.ok().body(NotMatchList.builder()
                 .notMatch(eventMatchingService.getNotMatchList(eventId)).build());
     }
+    @Operation(summary = "특정 VI의 매칭된 Guide 수 조회", description = "매칭 패널에서 특정 VI에 연결된 Guide 수를 조회합니다.")
     @GetMapping("{eventId}/match/{viId}/count")
     public ResponseEntity<MatchedGuideCount> getMatchedGuideCount(@PathVariable("eventId") Long eventId,
                                                                   @PathVariable("viId") String viId,
@@ -55,6 +65,7 @@ public class EventMatchingController {
         jwtProvider.extractUserId(request);
         return ResponseEntity.ok().body(eventMatchingService.getMatchedGuideCount(eventId,viId));
     }
+    @Operation(summary = "특정 VI의 매칭된 Guide 목록 조회", description = "매칭 패널과 매칭 박스에서 특정 VI에 연결된 Guide 목록을 조회합니다.")
     @GetMapping("{eventId}/match/{viId}/list")
     public ResponseEntity<MatchedGuideList> getMatchedGuideList(@PathVariable("eventId") Long eventId,
                                                                 @PathVariable("viId") String viId,
@@ -62,18 +73,21 @@ public class EventMatchingController {
         jwtProvider.extractUserId(request);
         return ResponseEntity.ok().body(eventMatchingService.getMatchedGuideList(eventId,viId));
     }
+    @Operation(summary = "매칭된 VI 수 조회", description = "이벤트 상세의 매칭 패널에서 매칭이 존재하는 VI 수를 조회합니다.")
     @GetMapping("{eventId}/match/vi/count")
     public ResponseEntity<MatchedViCount> getMatchedViCount(@PathVariable("eventId") Long eventId,
                                                                HttpServletRequest request){
         jwtProvider.extractUserId(request);
         return ResponseEntity.ok().body(eventMatchingService.getMatchedViCount(eventId));
     }
+    @Operation(summary = "매칭된 VI 목록 조회", description = "이벤트 상세의 매칭 패널에서 매칭이 존재하는 VI 목록을 조회합니다.")
     @GetMapping("{eventId}/match/vi/list")
     public ResponseEntity<MatchedViList> getMatchedViList(@PathVariable("eventId") Long eventId,
                                                             HttpServletRequest request){
         jwtProvider.extractUserId(request);
         return ResponseEntity.ok().body(eventMatchingService.getMatchedViList(eventId));
     }
+    @Operation(summary = "자동 매칭 실행", description = "이벤트 상세의 매칭 패널에서 현재 신청자 기준 자동 매칭을 실행합니다.")
     @PostMapping("{eventId}/match/auto")
     public ResponseEntity<String> autoMatchUsers(@PathVariable("eventId") Long eventId,
                                                  HttpServletRequest request){

--- a/run/src/main/java/com/guide/run/event/controller/EventSearchController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventSearchController.java
@@ -6,6 +6,10 @@ import com.guide.run.event.service.EventSearchService;
 import com.guide.run.global.exception.user.resource.NotExistUserException;
 import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.user.repository.user.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,14 +20,17 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")
+@Tag(name = "Event", description = "이벤트 검색 API")
+@SecurityRequirement(name = "bearerAuth")
 public class EventSearchController {
     private final JwtProvider jwtProvider;
     private final EventSearchService eventSearchService;
     private final UserRepository userRepository;
+    @Operation(summary = "이벤트 검색 목록 조회", description = "이벤트 검색 화면에서 제목 기준으로 이벤트 목록을 페이지네이션 조회합니다.")
     @GetMapping("/search")
-    public SearchAllEventList searchAllEventList(@RequestParam("title") String title,
-                                                 @RequestParam("limit") int limit,
-                                                 @RequestParam("start") int start,
+    public SearchAllEventList searchAllEventList(@Parameter(description = "검색어", example = "상계천") @RequestParam("title") String title,
+                                                 @Parameter(description = "페이지 크기", example = "10") @RequestParam("limit") int limit,
+                                                 @Parameter(description = "페이지 시작 offset", example = "0") @RequestParam("start") int start,
                                                  HttpServletRequest request){
         extracted(request);
         System.out.println("title = " + title);
@@ -32,8 +39,9 @@ public class EventSearchController {
                 .build();
     }
 
+    @Operation(summary = "이벤트 검색 개수 조회", description = "이벤트 검색 화면에서 제목 기준 검색 결과 개수를 조회합니다.")
     @GetMapping("/search/count")
-    public SearchAllEventsCount searchAllEventCount(@RequestParam("title") String title,
+    public SearchAllEventsCount searchAllEventCount(@Parameter(description = "검색어", example = "상계천") @RequestParam("title") String title,
                                                     HttpServletRequest request){
         extracted(request);
         return eventSearchService.getSearchAllEventsCount(title);

--- a/run/src/main/java/com/guide/run/event/entity/dto/request/EventCommentCreateRequest.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/request/EventCommentCreateRequest.java
@@ -1,10 +1,13 @@
 package com.guide.run.event.entity.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "이벤트 댓글 작성/수정 요청")
 public class EventCommentCreateRequest {
+    @Schema(description = "댓글 내용", example = "이번 주 토요일에도 참여할게요.")
     private String content;
 
     //dto json 변환시 객체 하나만 있으면 파업하므로 아래 어노테이션 붙여줘야함

--- a/run/src/main/java/com/guide/run/event/entity/dto/request/form/CreateEventForm.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/request/form/CreateEventForm.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.entity.dto.request.form;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,8 +8,12 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 @Getter
+@Schema(description = "이벤트 신청서 생성/수정 요청")
 public class CreateEventForm {
+    @Schema(description = "희망 그룹 또는 페이스", example = "A")
     private String group;
+    @Schema(description = "희망 파트너 이름", example = "김가이드")
     private String partner;
+    @Schema(description = "추가 요청사항 및 상세 내용", example = "대회용 티셔츠는 M 사이즈 희망")
     private String detail;
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/EventPopUpResponse.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/EventPopUpResponse.java
@@ -2,6 +2,7 @@ package com.guide.run.event.entity.dto.response;
 
 import com.guide.run.event.entity.type.*;
 import com.guide.run.user.entity.type.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,8 +15,11 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "이벤트 팝업/모달 상세 응답")
 public class EventPopUpResponse {
+        @Schema(description = "이벤트 ID", example = "1023")
         private Long eventId;
+        @Schema(description = "이벤트 유형", example = "TRAINING")
         private EventType type;//이벤트 분류
 
         private String organizerId; //주최자 아이디
@@ -36,7 +40,9 @@ public class EventPopUpResponse {
         private String content;//이벤트 내용
         private LocalDate updatedAt; //수정일
 
+        @Schema(description = "현재 로그인 사용자의 신청 여부", example = "true")
         private Boolean isApply; //신청 여부
+        @Schema(description = "파트너 정보 존재 여부", example = "false")
         private Boolean hasPartner; //파트너 존재 여부
 
         private List<EventPopUpPartner> partner;

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/LikeCountResponse.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/LikeCountResponse.java
@@ -1,6 +1,7 @@
 package com.guide.run.event.entity.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,8 +9,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
+@Schema(description = "좋아요 수와 내 좋아요 여부 응답")
 public class LikeCountResponse {
+    @Schema(description = "총 좋아요 수", example = "14")
     private Long likes;
     @JsonProperty(value = "isLiked")
+    @Schema(description = "현재 로그인 사용자의 좋아요 여부", example = "true")
     private Boolean isLiked; //boolean 하면 liked 값이 생겨버림
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/attend/ParticipationCount.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/attend/ParticipationCount.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.entity.dto.response.attend;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,8 +8,12 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
+@Schema(description = "이벤트 신청 현황 개수 응답")
 public class ParticipationCount {
+    @Schema(description = "총 신청자 수", example = "10")
     private Long count;
+    @Schema(description = "VI 신청자 수", example = "4")
     private Long vi;
+    @Schema(description = "Guide 신청자 수", example = "6")
     private Long guide;
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/comments/GetComment.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/comments/GetComment.java
@@ -1,19 +1,26 @@
 package com.guide.run.event.entity.dto.response.comments;
 
 import com.guide.run.user.entity.type.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
+@Schema(description = "이벤트 댓글 항목")
 public class GetComment {
+    @Schema(description = "댓글 ID", example = "301")
     private Long commentId;
+    @Schema(description = "작성자 이름", example = "홍길동")
     private String name;
+    @Schema(description = "작성자 사용자 ID", example = "guide_102")
     private String userId;
     private UserType type;
+    @Schema(description = "댓글 내용", example = "이번 주 토요일에도 참여할게요.")
     private String content;
     private LocalDate createdAt;
+    @Schema(description = "좋아요 수", example = "3")
     private long likes;
 
     public GetComment(Long commentId, String name,String userId, UserType type, String content, LocalDateTime createdAt, Long likes) {

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/comments/response/CommentsGetResponse.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/comments/response/CommentsGetResponse.java
@@ -1,6 +1,7 @@
 package com.guide.run.event.entity.dto.response.comments.response;
 
 import com.guide.run.event.entity.dto.response.comments.GetComment;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,8 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @Builder
+@Schema(description = "이벤트 댓글 목록 응답")
 public class CommentsGetResponse {
+    @Schema(description = "댓글 목록")
     private List<GetComment> comments;
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEventResponse.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEventResponse.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.entity.dto.response.get;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,8 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
+@Schema(description = "전체 이벤트 목록 응답")
 public class AllEventResponse {
+    @Schema(description = "이벤트 목록")
     private List<AllEvent> items;
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/Count.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/Count.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.entity.dto.response.get;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +8,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
+@Schema(description = "공통 개수 응답")
 public class Count {
+    @Schema(description = "조회 결과 개수", example = "12")
     private long count;
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEvent.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEvent.java
@@ -2,6 +2,7 @@ package com.guide.run.event.entity.dto.response.get;
 
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,10 +13,15 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @AllArgsConstructor
+@Schema(description = "나의 이벤트 목록 항목")
 public class MyEvent {
+    @Schema(description = "이벤트 ID", example = "1023")
     private Long eventId;
+    @Schema(description = "이벤트 유형", example = "TRAINING")
     private EventType eventType;
+    @Schema(description = "이벤트 이름", example = "상계천 천천히 달리기")
     private String name;
+    @Schema(description = "D-day", example = "7")
     private int dDay;
     private LocalDate endDate;
     private EventRecruitStatus recruitStatus;

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEventResponse.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEventResponse.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.entity.dto.response.get;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,8 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
+@Schema(description = "나의 이벤트 목록 응답")
 public class MyEventResponse {
+    @Schema(description = "나의 이벤트 목록")
     private List<MyEvent> items;
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/match/UserTypeCount.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/match/UserTypeCount.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.entity.dto.response.match;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,7 +8,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
+@Schema(description = "미매칭 사용자 유형별 개수 응답")
 public class UserTypeCount {
+    @Schema(description = "미매칭 VI 수", example = "2")
     private long vi;
+    @Schema(description = "미매칭 Guide 수", example = "3")
     private long guide;
 }

--- a/run/src/main/java/com/guide/run/global/config/SwaggerConfig.java
+++ b/run/src/main/java/com/guide/run/global/config/SwaggerConfig.java
@@ -1,12 +1,11 @@
 package com.guide.run.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.responses.ApiResponse;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.customizers.OperationCustomizer;
@@ -26,12 +25,11 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(new Info()
                         .title("GuideRun API")
-                        .description("GuideRun 백엔드 API 문서")
+                        .description("GuideRun 백엔드 API 문서. 실제 서버 계약을 기준으로 정리되어 있으며, 프론트 사용 흐름에 맞춘 설명과 예시를 제공합니다.")
                         .version("v1")
                         .license(new License().name("GuideRun"))
                         .termsOfService("https://guidesrun.kr"))
-                .components(new Components())
-                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+                .components(new Components());
     }
 
     @Bean
@@ -39,7 +37,15 @@ public class SwaggerConfig {
         return GroupedOpenApi.builder()
                 .group("public")
                 .pathsToMatch("/api/**")
-                .pathsToExclude("/api/admin/**")
+                .pathsToExclude("/api/admin/**", "/api/test/**", "/api/test2", "/api/test3", "/api/event/test/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi adminApi() {
+        return GroupedOpenApi.builder()
+                .group("admin")
+                .pathsToMatch("/api/admin/**")
                 .build();
     }
 

--- a/run/src/main/java/com/guide/run/partner/controller/PartnerController.java
+++ b/run/src/main/java/com/guide/run/partner/controller/PartnerController.java
@@ -2,6 +2,9 @@ package com.guide.run.partner.controller;
 
 import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.partner.service.PartnerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,11 +12,14 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "User Info", description = "사용자 프로필 좋아요 API")
+@SecurityRequirement(name = "bearerAuth")
 public class PartnerController {
 
     private final JwtProvider jwtProvider;
     private final PartnerService partnerService;
 
+    @Operation(summary = "사용자 좋아요 토글", description = "프로필 모달과 프로필 페이지에서 특정 사용자의 좋아요 상태를 토글합니다.")
     @PostMapping("api/user/like/{userId}")
     public ResponseEntity<String> partnerLike(@PathVariable String userId,
                                               HttpServletRequest request){

--- a/run/src/main/java/com/guide/run/user/controller/ImgController.java
+++ b/run/src/main/java/com/guide/run/user/controller/ImgController.java
@@ -3,6 +3,9 @@ package com.guide.run.user.controller;
 import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.user.dto.response.ImgResponse;
 import com.guide.run.user.service.ImgService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,10 +16,13 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "User Info", description = "프로필 이미지 업로드/삭제 API")
+@SecurityRequirement(name = "bearerAuth")
 public class ImgController {
     private final JwtProvider jwtProvider;
     private final ImgService imgService;
 
+    @Operation(summary = "프로필 이미지 업로드", description = "마이페이지에서 `files` multipart 필드로 프로필 이미지를 업로드합니다.")
     @PostMapping("/user/img")
     public ResponseEntity<ImgResponse> uploadProfile(@RequestParam MultipartFile files,
                                                      HttpServletRequest request){
@@ -28,6 +34,7 @@ public class ImgController {
         return ResponseEntity.status(HttpStatus.CREATED).body(img);
     }
 
+    @Operation(summary = "프로필 이미지 삭제", description = "현재 로그인 사용자의 프로필 이미지를 삭제합니다.")
     @DeleteMapping("/user/img")
     public ResponseEntity<String> deleteProfile(HttpServletRequest request){
         String privateId = jwtProvider.extractUserId(request);

--- a/run/src/main/java/com/guide/run/user/controller/LoginInfoController.java
+++ b/run/src/main/java/com/guide/run/user/controller/LoginInfoController.java
@@ -9,6 +9,8 @@ import com.guide.run.user.dto.request.*;
 import com.guide.run.user.dto.response.FindAccountIdDto;
 import com.guide.run.user.dto.response.TokenResponse;
 import com.guide.run.user.service.LoginInfoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -27,6 +29,7 @@ import java.security.NoSuchAlgorithmException;
 @CrossOrigin(origins = {"https://dev.guiderun.org", "https://guiderun.org","https://www.guiderun.org", "http://localhost:3000", "http://localhost:8080"},
         maxAge = 3600,
         allowCredentials = "true")
+@Tag(name = "Auth", description = "아이디 찾기, 비밀번호 재설정, 로그아웃과 관련된 인증 보조 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -37,6 +40,7 @@ public class LoginInfoController {
     private static final Logger log = LoggerFactory.getLogger(EventService.class);
 
     //인증번호 요청(아이디 찾기)
+    @Operation(summary = "아이디 찾기용 인증번호 요청", description = "전화번호만으로 아이디 찾기 인증번호를 발송합니다.", security = {})
     @PostMapping("/sms/accountId")
     public ResponseEntity<String> getNumberForAccountId(@RequestBody PhoneNumberRequest request) throws UnsupportedEncodingException, URISyntaxException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         loginInfoService.getNumberForAccountId(request.getPhoneNum());
@@ -44,6 +48,7 @@ public class LoginInfoController {
     }
 
     //인증번호 요청(비밀번호 재설정)
+    @Operation(summary = "비밀번호 재설정용 인증번호 요청", description = "accountId와 전화번호를 함께 받아 비밀번호 재설정용 인증번호를 발송합니다.", security = {})
     @PostMapping("/sms/password")
     public ResponseEntity<String> getNumberForPassword(@RequestBody AccountIdPhoneRequest request)
             throws UnsupportedEncodingException, URISyntaxException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
@@ -52,22 +57,26 @@ public class LoginInfoController {
     }
 
     //인증번호 확인(아이디 찾기, 비밀번호 재설정용 토큰 발급)
+    @Operation(summary = "인증번호 검증", description = "문자로 받은 인증번호를 검증하고 아이디 찾기 또는 비밀번호 재설정에 사용할 임시 토큰을 발급합니다.", security = {})
     @PostMapping("/sms/token")
     public ResponseEntity<TokenResponse> getToken(@RequestBody AuthNumRequest request){
         return ResponseEntity.ok(loginInfoService.getToken(request.getNumber()));
     }
 
     //아이디 찾기
+    @Operation(summary = "아이디 찾기", description = "임시 토큰으로 계정 ID와 계정 생성일을 조회합니다.", security = {})
     @PostMapping("/accountId")
     public ResponseEntity<FindAccountIdDto> findAccountId(@RequestBody TmpTokenDto tmpTokenDto){
         return ResponseEntity.ok(loginInfoService.findAccountId(tmpTokenDto.getToken()));
     }
     //비밀번호 재설정
+    @Operation(summary = "비밀번호 재설정", description = "임시 토큰을 사용해 새 비밀번호를 저장합니다.", security = {})
     @PatchMapping("/new-password")
     public ResponseEntity<String> createNewPassword(@RequestBody NewPasswordDto newPasswordDto){
         loginInfoService.createNewPassword(newPasswordDto.getToken(),newPasswordDto.getNewPassword());
         return ResponseEntity.ok("");
     }
+    @Operation(summary = "로그아웃", description = "refreshToken 쿠키를 삭제해 로그아웃합니다. 프론트에서는 로그인된 마이페이지에서 호출합니다.", security = {})
     @PostMapping("/logout")
     public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response){
 

--- a/run/src/main/java/com/guide/run/user/controller/MypageController.java
+++ b/run/src/main/java/com/guide/run/user/controller/MypageController.java
@@ -10,6 +10,9 @@ import com.guide.run.user.dto.response.MyPagePartnerList;
 import com.guide.run.user.dto.response.ProfileResponse;
 import com.guide.run.user.service.MypageService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,12 +23,14 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
+@Tag(name = "User Info", description = "마이페이지, 프로필, 이벤트/파트너 이력 조회 API")
+@SecurityRequirement(name = "bearerAuth")
 public class MypageController {
 
     private final JwtProvider jwtProvider;
     private final MypageService mypageService;
 
-    @Operation(summary = "사용자 인적사항 조회")
+    @Operation(summary = "현재 로그인 사용자 정보 조회", description = "앱 초기 진입 후 사용자 스토어를 구성할 때 사용하는 기본 사용자 정보 조회 API입니다.")
     @GetMapping("/personal")
     public ResponseEntity<GlobalUserInfoDto> getGlobalUserInfo(HttpServletRequest httpServletRequest){
         String privateId = jwtProvider.extractUserId(httpServletRequest);
@@ -33,22 +38,28 @@ public class MypageController {
 
         return ResponseEntity.ok().body(response);
     }
-    @Operation(summary = "나의 이벤트 참여 횟수 조회")
+    @Operation(summary = "사용자 이벤트 이력 개수 조회", description = "프로필 모달과 이벤트 이력 화면에서 특정 사용자의 이벤트 이력 개수를 조회합니다. 실제 서버 query 이름은 `kind`입니다.")
     @GetMapping("/event-history/count/{userId}")
     public ResponseEntity<Count> getMyEventCount(@PathVariable String userId,
+                                                 @Parameter(description = "모집/진행 상태 필터", example = "RECRUIT_ALL")
                                                  @RequestParam(defaultValue = "RECRUIT_ALL") String kind,
+                                                 @Parameter(description = "조회 연도. 0이면 전체", example = "2026")
                                                  @RequestParam(defaultValue = "0") int year){
         Count response = Count.builder()
                 .count(mypageService.getMyPageEventsCount(userId, kind, year))
                 .build();
         return ResponseEntity.ok().body(response);
     }
-    @Operation(summary = "나의 이벤트 참여 목록 조회")
+    @Operation(summary = "사용자 이벤트 이력 목록 조회", description = "프로필 모달, 마이페이지, 이벤트 이력 화면에서 특정 사용자의 이벤트 이력을 페이지네이션으로 조회합니다.")
     @GetMapping("/event-history/{userId}")
     public ResponseEntity<MyPageEventList> getMyEventList(@PathVariable String userId,
+                                                          @Parameter(description = "페이지 시작 offset", example = "0")
                                                           @RequestParam(defaultValue = "0") int start,
+                                                          @Parameter(description = "조회 개수", example = "10")
                                                           @RequestParam(defaultValue = "10") int limit,
+                                                          @Parameter(description = "모집/진행 상태 필터", example = "RECRUIT_ALL")
                                                           @RequestParam(defaultValue = "RECRUIT_ALL") String kind,
+                                                          @Parameter(description = "조회 연도. 0이면 전체", example = "2026")
                                                           @RequestParam(defaultValue = "0") int year){
         MyPageEventList response = MyPageEventList.builder()
                 .items(mypageService.getMyPageEvents(userId,start,limit, kind, year))
@@ -57,7 +68,7 @@ public class MypageController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "사용자 프로필 상세 조회")
+    @Operation(summary = "사용자 프로필 상세 조회", description = "프로필 모달과 관리자 사용자 상세 화면에서 공개 프로필과 통계 정보를 조회합니다.")
     @GetMapping("/profile/{userId}")
     public ResponseEntity<ProfileResponse> getUserProfile(@PathVariable String userId,
                                                           HttpServletRequest request){
@@ -66,10 +77,14 @@ public class MypageController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "함께 뛴 파트너 목록 조회", description = "메인 화면과 파트너 목록 화면에서 특정 사용자의 파트너 목록을 조회합니다.")
     @GetMapping("/partner-list/{userId}")
     public ResponseEntity<MyPagePartnerList> getMyPartnerList(@PathVariable String userId,
+                                                              @Parameter(description = "페이지 시작 offset", example = "0")
                                                               @RequestParam(defaultValue = "0") int start,
+                                                              @Parameter(description = "조회 개수", example = "10")
                                                               @RequestParam(defaultValue = "10") int limit,
+                                                              @Parameter(description = "정렬 기준", example = "RECENT")
                                                               @RequestParam(defaultValue = "RECENT") String sort){
         MyPagePartnerList response = MyPagePartnerList.builder()
                 .items(mypageService.getMyPagePartners(userId, start, limit, sort))
@@ -77,6 +92,7 @@ public class MypageController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "함께 뛴 파트너 수 조회", description = "메인 화면과 파트너 목록 화면에서 특정 사용자의 파트너 수를 조회합니다.")
     @GetMapping("/partner-list/count/{userId}")
     public ResponseEntity<Count> getMyPartnerCount(@PathVariable String userId){
         Count response = Count.builder()
@@ -86,11 +102,13 @@ public class MypageController {
         return ResponseEntity.ok().body(response);
     }
 
-    @GetMapping("event-type/count/{userId}")
+    @Operation(summary = "이벤트 유형별 참여 수 조회", description = "프로필과 통계 영역에서 훈련/대회 참여 건수를 조회합니다.")
+    @GetMapping("/event-type/count/{userId}")
     public ResponseEntity<EventTypeCountDto> getEventTypeCount(@PathVariable String userId){
         return ResponseEntity.ok(mypageService.getMyPageEventTypeCount(userId));
     }
 
+    @Operation(summary = "1365 아이디 저장", description = "정보 수정 화면에서 1365 아이디를 저장합니다.")
     @PostMapping("/personal/1365id")
     public ResponseEntity<String> add1365(HttpServletRequest httpServletRequest, @RequestBody Add1365Dto add1365Dto){
         String privateId = jwtProvider.extractUserId(httpServletRequest);

--- a/run/src/main/java/com/guide/run/user/controller/SignController.java
+++ b/run/src/main/java/com/guide/run/user/controller/SignController.java
@@ -18,6 +18,9 @@ import com.guide.run.user.service.GuideService;
 import com.guide.run.user.service.ProviderService;
 import com.guide.run.user.service.UserService;
 import com.guide.run.user.service.ViService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.Cookie;
@@ -36,6 +39,7 @@ import javax.naming.CommunicationException;
 @CrossOrigin(origins = {"https://dev.guiderun.org", "https://guiderun.org","https://www.guiderun.org", "http://localhost:3000", "http://localhost:8080"},
 maxAge = 3600,
 allowCredentials = "true")
+@Tag(name = "Auth", description = "로그인, 회원가입, 토큰 재발급, 중복 확인과 회원 탈퇴를 다루는 인증 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -48,6 +52,7 @@ public class SignController {
     private final GuideService guideService;
 
 
+    @Operation(summary = "일반 로그인", description = "로그인 화면에서 계정 ID와 비밀번호로 로그인합니다. 응답 본문에는 액세스 토큰을, 브라우저 쿠키에는 refreshToken을 내려줍니다.", security = {})
     @PostMapping("/login")
     public LoginResponse generalLogin(@RequestBody GeneralLoginRequest request,HttpServletRequest httpServletRequest,
                                       HttpServletResponse httpServletResponse){
@@ -78,8 +83,9 @@ public class SignController {
                 .build();
     }
 
+    @Operation(summary = "카카오 OAuth 로그인", description = "프론트 OAuth 콜백 화면에서 받은 카카오 인가 코드를 전달받아 로그인합니다. 신규 사용자는 `isExist=false`로 내려와 추가 회원가입 흐름으로 이동합니다.", security = {})
     @PostMapping("/oauth/login/kakao")
-    public LoginResponse kakaoLogin(String code, HttpServletRequest request,HttpServletResponse response) throws CommunicationException {
+    public LoginResponse kakaoLogin(@RequestParam("code") String code, HttpServletRequest request,HttpServletResponse response) throws CommunicationException {
         String accessToken = providerService.getAccessToken(code, "kakao").getAccess_token();
         OAuthProfile oAuthProfile = providerService.getProfile(accessToken,"kakao");
         String privateId = oAuthProfile.getSocialId();
@@ -108,6 +114,7 @@ public class SignController {
                 .build();
     }
 
+    @Operation(summary = "VI 회원가입 완료", description = "소셜 로그인 후 NEW 권한 사용자가 VI 회원가입 폼을 제출할 때 호출됩니다. 프론트의 회원가입 화면에서 입력한 기본 정보, 러닝 정보, 약관 동의 정보를 함께 받습니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @PostMapping("/signup/vi")
     public ResponseEntity<SignupResponse> viSignup(@RequestBody @Valid ViSignupDto viSignupDto, HttpServletRequest httpServletRequest){
         String privateId = jwtProvider.extractUserId(httpServletRequest);
@@ -121,6 +128,7 @@ public class SignController {
     }
 
 
+    @Operation(summary = "Guide 회원가입 완료", description = "소셜 로그인 후 NEW 권한 사용자가 Guide 회원가입 폼을 제출할 때 호출됩니다. 프론트의 회원가입 화면에서 입력한 기본 정보와 가이드 경험 정보를 함께 받습니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @PostMapping("/signup/guide")
     public ResponseEntity<SignupResponse> guideSignup(@RequestBody @Valid GuideSignupDto guideSignupDto, HttpServletRequest httpServletRequest){
         String privateId = jwtProvider.extractUserId(httpServletRequest);
@@ -134,8 +142,9 @@ public class SignController {
     }
 
 
+    @Operation(summary = "구글 OAuth 토큰 교환", description = "구글 인가 코드를 액세스 토큰으로 교환합니다. 현재 프론트 실사용 흐름보다는 보조 인증 경로에 가깝습니다.", security = {})
     @PostMapping("/oauth/token/google")
-    public LoginResponse googleSignup(String code,HttpServletResponse response) throws CommunicationException {
+    public LoginResponse googleSignup(@RequestParam("code") String code,HttpServletResponse response) throws CommunicationException {
         String accessToken = providerService.getAccessToken(code, "google").getAccess_token();
         OAuthProfile oAuthProfile = providerService.getProfile(accessToken,"google");
         String userId = oAuthProfile.getSocialId();
@@ -144,6 +153,7 @@ public class SignController {
                 .accessToken(jwtProvider.createAccessToken(userId))
                 .build();
     }
+    @Operation(summary = "액세스 토큰 재발급", description = "브라우저 쿠키의 refreshToken으로 액세스 토큰을 재발급합니다. 프론트 앱 초기 진입과 401 재시도 처리에서 사용됩니다.", security = {})
     @GetMapping("/oauth/login/reissue")
     public ReissuedAccessTokenDto accessTokenReissue(HttpServletRequest request, HttpServletResponse response){
         Cookie[] cookies = request.getCookies();
@@ -185,6 +195,7 @@ public class SignController {
     }
 
     //아이디 중복확인
+    @Operation(summary = "회원가입용 계정 ID 중복 확인", description = "회원가입 화면에서 입력한 accountId가 사용 가능한지 확인합니다. 소셜 로그인 이후 NEW 권한 상태에서 호출됩니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @PostMapping("/signup/duplicated")
     public ResponseEntity<IsDuplicatedResponse> isIdDuplicated(@RequestBody AccountIdDto aa){
         IsDuplicatedResponse response =
@@ -194,6 +205,7 @@ public class SignController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 화면에서 선택한 탈퇴 사유 목록을 저장하고 계정을 탈퇴 처리합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @DeleteMapping("/withdrawal")
     public ResponseEntity<String> withDrawal(@RequestBody WithdrawalRequest request, HttpServletRequest httpServletRequest){
         String privateId = jwtProvider.extractUserId(httpServletRequest);
@@ -201,8 +213,9 @@ public class SignController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body("");
     }
 
+    @Operation(summary = "네이버 OAuth 로그인", description = "네이버 인가 코드를 전달받아 로그인합니다. 현재 프론트의 주 인증 경로는 아니지만 운영 가능한 공개 인증 API입니다.", security = {})
     @PostMapping("/oauth/login/naver")
-    public LoginResponse naverLogin(String code, HttpServletRequest request,HttpServletResponse response) throws CommunicationException {
+    public LoginResponse naverLogin(@RequestParam("code") String code, HttpServletRequest request,HttpServletResponse response) throws CommunicationException {
         String accessToken = providerService.getAccessToken(code, "naver").getAccess_token();
         OAuthProfile oAuthProfile = providerService.getProfile(accessToken,"naver");
         String privateId = oAuthProfile.getSocialId();

--- a/run/src/main/java/com/guide/run/user/controller/SignupInfoController.java
+++ b/run/src/main/java/com/guide/run/user/controller/SignupInfoController.java
@@ -6,6 +6,9 @@ import com.guide.run.user.dto.PermissionDto;
 import com.guide.run.user.dto.PersonalInfoDto;
 import com.guide.run.user.dto.ViRunningInfoDto;
 import com.guide.run.user.service.SignupInfoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,11 +18,14 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "User Info", description = "회원 기본 정보, 약관 동의, 러닝 스펙 조회/수정 API")
+@SecurityRequirement(name = "bearerAuth")
 public class SignupInfoController {
     private final SignupInfoService signupInfoService;
     private final JwtProvider jwtProvider;
 
     //약관 동의 조회
+    @Operation(summary = "약관 동의 조회", description = "정보 페이지와 관리자 사용자 상세 화면에서 개인정보/초상권 동의 상태를 조회합니다.")
     @GetMapping("/user/permission/{userId}")
     public ResponseEntity<PermissionDto> getPermission(@PathVariable String userId,
                                                        HttpServletRequest httpServletRequest){
@@ -31,6 +37,7 @@ public class SignupInfoController {
     }
 
     //약관 동의 수정
+    @Operation(summary = "약관 동의 수정", description = "정보 수정 화면에서 개인정보/초상권 동의 여부를 저장합니다.")
     @PatchMapping("/user/permission")
     public ResponseEntity<PermissionDto> editPermission(@RequestBody PermissionDto request,
                                                         HttpServletRequest httpServletRequest){
@@ -41,6 +48,7 @@ public class SignupInfoController {
     }
 
     //인적사항 조회
+    @Operation(summary = "기본 인적사항 조회", description = "정보 페이지와 관리자 상세 패널에서 회원가입 시 입력한 기본 인적사항을 조회합니다.")
     @GetMapping("/user/personal/{userId}")
     public ResponseEntity<PersonalInfoDto> getPersonalInfo(@PathVariable String userId,
                                                            HttpServletRequest httpServletRequest){
@@ -51,6 +59,7 @@ public class SignupInfoController {
     }
 
     //인적사항 수정
+    @Operation(summary = "기본 인적사항 수정", description = "정보 수정 화면에서 이름, 연락처 공개 여부, SNS 공개 여부 등 기본 인적사항을 저장합니다.")
     @PatchMapping("/user/personal")
     public ResponseEntity<PersonalInfoDto> editPersonalInfo(@RequestBody PersonalInfoDto personalInfoDto,
                                                             HttpServletRequest httpServletRequest){
@@ -61,6 +70,7 @@ public class SignupInfoController {
     }
 
     //러닝 스펙 조회 vi
+    @Operation(summary = "VI 러닝 스펙 조회", description = "정보 페이지와 관리자 사용자 상세 화면에서 VI 사용자의 러닝 스펙을 조회합니다.")
     @GetMapping("/user/running/vi/{userId}")
     public ResponseEntity<ViRunningInfoDto> getViRunningInfo(@PathVariable String userId,
                                                              HttpServletRequest httpServletRequest){
@@ -70,6 +80,7 @@ public class SignupInfoController {
         return ResponseEntity.ok().body(response);
     }
     //러닝 스펙 조회 guide
+    @Operation(summary = "Guide 러닝 스펙 조회", description = "정보 페이지와 관리자 사용자 상세 화면에서 Guide 사용자의 러닝 스펙을 조회합니다.")
     @GetMapping("/user/running/guide/{userId}")
     public ResponseEntity<GuideRunningInfoDto> getGuideRunningInfo(@PathVariable String userId,
                                                                    HttpServletRequest httpServletRequest){
@@ -80,6 +91,7 @@ public class SignupInfoController {
     }
 
     //vi 러닝스펙 수정
+    @Operation(summary = "VI 러닝 스펙 수정", description = "정보 수정 화면에서 VI 사용자의 러닝 스펙을 저장합니다.")
     @PatchMapping("/user/running/vi")
     public ResponseEntity<ViRunningInfoDto> editViRunningInfo(HttpServletRequest httpServletRequest,
                                                               @RequestBody ViRunningInfoDto request){
@@ -89,6 +101,7 @@ public class SignupInfoController {
     }
 
     //guide 러닝 스펙 수정
+    @Operation(summary = "Guide 러닝 스펙 수정", description = "정보 수정 화면에서 Guide 사용자의 러닝 스펙을 저장합니다.")
     @PatchMapping("/user/running/guide")
     public ResponseEntity<GuideRunningInfoDto> editGuideRunningInfo(HttpServletRequest httpServletRequest,
                                                               @RequestBody GuideRunningInfoDto request){

--- a/run/src/main/java/com/guide/run/user/controller/UserInfoController.java
+++ b/run/src/main/java/com/guide/run/user/controller/UserInfoController.java
@@ -2,6 +2,9 @@ package com.guide.run.user.controller;
 
 import com.guide.run.user.dto.response.UserInfoAll.UserInfoAllResponse;
 import com.guide.run.user.service.GetUserInfoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,9 +12,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@Tag(name = "User Info", description = "사용자 전체 정보 조회 API")
+@SecurityRequirement(name = "bearerAuth")
 public class UserInfoController {
     private final GetUserInfoService getUserInfoService;
-    @GetMapping("api/user/info/all")
+    @Operation(summary = "전체 사용자 정보 조회", description = "Guide/VI 전체 정보를 한 번에 조회하는 내부성 성격의 API입니다.")
+    @GetMapping("/api/user/info/all")
     public ResponseEntity<UserInfoAllResponse> getUserInfoAll(){
         return ResponseEntity.ok(getUserInfoService.getUserInfoAll());
     }

--- a/run/src/main/java/com/guide/run/user/dto/GlobalUserInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/GlobalUserInfoDto.java
@@ -2,6 +2,7 @@ package com.guide.run.user.dto;
 
 import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.entity.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,13 +12,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "현재 로그인 사용자 기본 정보")
 public class GlobalUserInfoDto {
+    @Schema(description = "공개 사용자 ID", example = "guide_102")
     private String userId;
+    @Schema(description = "이름", example = "홍길동")
     private String name;
+    @Schema(description = "사용자 유형", example = "GUIDE")
     private UserType type;
+    @Schema(description = "권한", example = "USER")
     private String role;
+    @Schema(description = "성별", example = "MALE")
     private String gender;
+    @Schema(description = "휴대전화 번호", example = "01012345678")
     private String phoneNumber;
+    @Schema(description = "러닝 등급", example = "A")
     private String recordDegree;
     private int age;
     private String snsId;

--- a/run/src/main/java/com/guide/run/user/dto/GuideRunningInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/GuideRunningInfoDto.java
@@ -3,6 +3,7 @@ package com.guide.run.user.dto;
 import com.guide.run.user.entity.ArchiveData;
 import com.guide.run.user.entity.user.Guide;
 import com.guide.run.user.entity.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,9 +16,13 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "Guide 사용자 러닝 스펙")
 public class GuideRunningInfoDto {
+    @Schema(description = "현재 러닝 등급", example = "A")
     private String recordDegree;
+    @Schema(description = "세부 기록", example = "10km 48분")
     private String detailRecord;
+    @Schema(description = "가이드 경험 여부", example = "true")
     private Boolean isGuideExp;
     private String viName;
     private String viRecord;

--- a/run/src/main/java/com/guide/run/user/dto/PermissionDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/PermissionDto.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,7 +8,10 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
+@Schema(description = "약관 동의 정보")
 public class PermissionDto {
+    @Schema(description = "개인정보 수집 및 이용 동의", example = "true")
     private boolean privacy;
+    @Schema(description = "초상권 활용 동의", example = "true")
     private boolean portraitRights;
 }

--- a/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
@@ -1,6 +1,7 @@
 package com.guide.run.user.dto;
 
 import com.guide.run.user.entity.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,11 +9,17 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
+@Schema(description = "회원 기본 인적사항")
 public class PersonalInfoDto {
+    @Schema(description = "권한", example = "USER")
     private String role;
+    @Schema(description = "사용자 유형", example = "GUIDE")
     private String type;
+    @Schema(description = "성별", example = "MALE")
     private String gender;
+    @Schema(description = "이름", example = "홍길동")
     private String name;
+    @Schema(description = "휴대전화 번호", example = "01012345678")
     private String phoneNumber;
     private Boolean isOpenNumber;
     private int age;

--- a/run/src/main/java/com/guide/run/user/dto/ReissuedAccessTokenDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/ReissuedAccessTokenDto.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,7 +8,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
+@Schema(description = "액세스 토큰 재발급 응답")
 public class ReissuedAccessTokenDto {
+    @Schema(description = "재발급된 액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
     private String accessToken;
+    @Schema(description = "추가 회원가입 없이 바로 서비스 사용 가능한지 여부", example = "true")
     private Boolean isExist;
 }

--- a/run/src/main/java/com/guide/run/user/dto/ViRunningInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/ViRunningInfoDto.java
@@ -3,6 +3,7 @@ package com.guide.run.user.dto;
 import com.guide.run.user.entity.ArchiveData;
 import com.guide.run.user.entity.user.User;
 import com.guide.run.user.entity.user.Vi;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,9 +16,13 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(description = "VI 사용자 러닝 스펙")
 public class ViRunningInfoDto {
+    @Schema(description = "현재 러닝 등급", example = "B")
     private String recordDegree;
+    @Schema(description = "세부 기록", example = "10km 55분")
     private String detailRecord;
+    @Schema(description = "러닝 경험 여부", example = "true")
     private Boolean isRunningExp;
     @Builder.Default
     private List<String> howToKnow = new ArrayList<>(); //러닝 경험 없을 시 null

--- a/run/src/main/java/com/guide/run/user/dto/request/AccountIdDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/AccountIdDto.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(description = "회원가입 계정 ID 중복 확인 요청")
 public class AccountIdDto {
+    @Schema(description = "확인할 계정 ID", example = "runner01")
     private String accountId;
 }

--- a/run/src/main/java/com/guide/run/user/dto/request/AccountIdPhoneRequest.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/AccountIdPhoneRequest.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,10 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(description = "비밀번호 재설정용 인증번호 요청")
 public class AccountIdPhoneRequest {
+    @Schema(description = "계정 ID", example = "runner01")
     private String accountId;
+    @Schema(description = "본인 확인 휴대전화 번호", example = "01012345678")
     private String phoneNum;
 }

--- a/run/src/main/java/com/guide/run/user/dto/request/Add1365Dto.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/Add1365Dto.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(description = "1365 아이디 저장 요청")
 public class Add1365Dto {
+    @Schema(description = "저장할 1365 아이디", example = "guide1365")
     private String id1365;
 }

--- a/run/src/main/java/com/guide/run/user/dto/request/AuthNumRequest.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/AuthNumRequest.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor
+@Schema(description = "문자 인증번호 검증 요청")
 public class AuthNumRequest {
+    @Schema(description = "문자로 받은 인증번호", example = "123456")
     private String number;
 }

--- a/run/src/main/java/com/guide/run/user/dto/request/NewPasswordDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/NewPasswordDto.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "비밀번호 재설정 요청")
 public class NewPasswordDto {
+    @Schema(description = "인증 완료 후 발급된 임시 토큰", example = "tmp-token-1234")
     private String token;
+    @Schema(description = "새 비밀번호", example = "n3wP@ssword!")
     private String newPassword;
 }

--- a/run/src/main/java/com/guide/run/user/dto/request/PhoneNumberRequest.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/PhoneNumberRequest.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +11,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "전화번호 인증번호 요청")
 public class PhoneNumberRequest {
     @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\s|-)?(?:\\d{3}|\\d{4})?(?:\\s|-)?\\d{4}$")
+    @Schema(description = "본인 확인 휴대전화 번호", example = "01012345678")
     private String phoneNum;
 }

--- a/run/src/main/java/com/guide/run/user/dto/request/TmpTokenDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/TmpTokenDto.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor
+@Schema(description = "임시 토큰 기반 조회 요청")
 public class TmpTokenDto {
+    @Schema(description = "아이디 찾기/비밀번호 재설정에 사용할 임시 토큰", example = "tmp-token-1234")
     private String token;
 }

--- a/run/src/main/java/com/guide/run/user/dto/request/WithdrawalRequest.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/WithdrawalRequest.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,8 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(description = "회원 탈퇴 요청")
 public class WithdrawalRequest {
+    @Schema(description = "선택한 탈퇴 사유 목록", example = "[\"서비스를 거의 이용하지 않아요\", \"원하는 이벤트가 없어요\"]")
     private List<String> reasons = new ArrayList<>();
 }

--- a/run/src/main/java/com/guide/run/user/dto/response/FindAccountIdDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/FindAccountIdDto.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,7 +8,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
+@Schema(description = "아이디 찾기 응답")
 public class FindAccountIdDto {
+    @Schema(description = "찾은 계정 ID", example = "runner01")
     private String accountId;
+    @Schema(description = "계정 생성일", example = "2025-03-01")
     private String createdAt;
 }

--- a/run/src/main/java/com/guide/run/user/dto/response/ImgResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/ImgResponse.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "프로필 이미지 업로드 응답")
 public class ImgResponse {
+    @Schema(description = "업로드된 이미지 URL", example = "https://cdn.guiderun.org/profile/guide_102.png")
     private String img;
 }

--- a/run/src/main/java/com/guide/run/user/dto/response/IsDuplicatedResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/IsDuplicatedResponse.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "계정 ID 중복 확인 응답")
 public class IsDuplicatedResponse {
+    @Schema(description = "사용 가능한 계정 ID 여부", example = "true")
     private Boolean isUnique;
 }

--- a/run/src/main/java/com/guide/run/user/dto/response/ProfileResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/ProfileResponse.java
@@ -1,6 +1,7 @@
 package com.guide.run.user.dto.response;
 
 import com.guide.run.user.entity.type.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,12 +11,19 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "사용자 프로필 상세 응답")
 public class ProfileResponse {
+    @Schema(description = "공개 사용자 ID", example = "guide_102")
     private String userId;
+    @Schema(description = "권한", example = "USER")
     private String role;
+    @Schema(description = "이름", example = "홍길동")
     private String name;
+    @Schema(description = "사용자 유형", example = "GUIDE")
     private UserType type;
+    @Schema(description = "성별", example = "MALE")
     private String gender;
+    @Schema(description = "러닝 등급", example = "A")
     private String recordDegree;
     private String detailRecord;
     private String phoneNumber;
@@ -29,7 +37,9 @@ public class ProfileResponse {
 
     //2차 때 추가된 부분
     private String img;
+    @Schema(description = "현재 로그인 사용자의 좋아요 여부", example = "true")
     private Boolean isLiked;
+    @Schema(description = "누적 좋아요 수", example = "12")
     private int like;
 
     private String id1365;

--- a/run/src/main/java/com/guide/run/user/dto/response/SignupResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/SignupResponse.java
@@ -1,13 +1,18 @@
 package com.guide.run.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "회원가입 완료 응답")
 public class SignupResponse {
+    @Schema(description = "생성된 공개 사용자 ID", example = "guide_102")
     private String userId;
+    @Schema(description = "회원가입 완료 후 사용할 액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
     private String accessToken;
+    @Schema(description = "회원 상태", example = "USER")
     private String userStatus;
 }

--- a/run/src/main/java/com/guide/run/user/dto/response/TokenResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/TokenResponse.java
@@ -1,5 +1,6 @@
 package com.guide.run.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +8,8 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
+@Schema(description = "임시 인증 토큰 응답")
 public class TokenResponse {
+    @Schema(description = "아이디 찾기/비밀번호 재설정에 사용하는 임시 토큰", example = "tmp-token-1234")
     private String token;
 }


### PR DESCRIPTION
## 변경 배경
- `guiderun-front`에서 실제 사용하는 API 흐름을 기준으로 Swagger 문서를 더 읽기 쉽게 정리했습니다.
- 기존에는 일부 DTO `@Schema`와 기본 summary 중심이라, 화면 단에서 어떤 API를 어떤 의미로 쓰는지 파악하기 어려운 부분이 있었습니다.

## 주요 변경 사항
- Swagger 설정 보강
- `/api/admin/**` 전용 `admin` 그룹을 추가해 관리자 API도 Swagger UI에서 분리 노출되도록 정리
- 테스트성 경로는 문서 그룹에서 제외
- OpenAPI 설명 문구를 실제 서버 계약 기준 문서라는 방향으로 보강

- 사용자/인증 API 문서화
- 로그인, OAuth 로그인, 토큰 재발급, 문자 인증, 비밀번호 재설정, 회원가입, 프로필/러닝 정보/약관 조회 및 수정 API에 `@Tag`, `@Operation`, `@Schema` 추가
- 인증 필요 여부와 화면 사용 맥락이 Swagger에서 바로 보이도록 정리

- 이벤트 API 문서화
- 이벤트 생성/수정/삭제/상세, 목록/검색/캘린더, 신청서, 댓글, 좋아요, 출석, 매칭 API에 설명 추가
- 프론트에서 실제 쓰는 query/body 의미와 응답 wrapper 구조를 드러내도록 DTO 설명 보강

- 관리자 API 문서화
- 회원 목록/승인, 이벤트 목록/승인/결과, 검색, 탈퇴 회원, 파트너 이력 API를 관리자 화면 기준으로 설명 추가
- 목록 응답과 아이템 DTO에 스키마 설명 추가

- 계약 괴리 메모 추가
- Swagger는 실제 백엔드 계약 기준으로 유지하고, 프론트 helper/mock과 차이가 있는 항목은 `run/docs/swagger-contract-gaps.md`에 정리

## 검증
- `./gradlew compileJava` 성공
- 로컬 `bootRun`은 시도했지만 DB 연결(`Communications link failure`) 문제로 애플리케이션 기동까지는 확인하지 못했습니다.

## 비고
- 비즈니스 로직, 서비스 처리, DB 저장/조회 로직은 변경하지 않았습니다.
- 주 변경은 Swagger/OpenAPI 메타데이터와 문서 설명 보강입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 엔드포인트에 대한 Swagger 문서화를 강화하여 API 명세의 일관성과 가독성을 개선했습니다.
  * 요청 매개변수에 명시적 바인딩과 설명을 추가하여 API 사용의 명확성을 향상시켰습니다.
  * 인증 및 검색 기능을 포함한 여러 API 엔드포인트에 보안 요구사항 메타데이터를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->