### PR TITLE
docs: 프론트 사용처 기준으로 Swagger 문서 구체화

### DIFF
--- a/run/src/main/java/com/guide/run/global/config/SwaggerConfig.java
+++ b/run/src/main/java/com/guide/run/global/config/SwaggerConfig.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
@@ -29,7 +28,13 @@ public class SwaggerConfig {
                         .version("v1")
                         .license(new License().name("GuideRun"))
                         .termsOfService("https://guidesrun.kr"))
-                .components(new Components());
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")));
     }
 
     @Bean
@@ -61,19 +66,6 @@ public class SwaggerConfig {
             }
             addDefaultResponses(operation);
             return operation;
-        };
-    }
-
-    @Bean
-    public OpenApiCustomizer openApiSecurityCustomizer() {
-        return openApi -> {
-            openApi.getComponents().addSecuritySchemes("bearerAuth",
-                    new SecurityScheme()
-                            .type(SecurityScheme.Type.HTTP)
-                            .scheme("bearer")
-                            .bearerFormat("JWT")
-                            .in(SecurityScheme.In.HEADER)
-                            .name("Authorization"));
         };
     }
 


### PR DESCRIPTION
## 변경 내용
- `guiderun-front`의 실제 API 사용처를 기준으로 Swagger 설명, 파라미터, 응답 예시를 구체화했습니다.
- 사용자 인증/회원정보, 이벤트, 관리자 API에 `@Tag`, `@Operation`, `@Schema`, `@SecurityRequirement`를 보강했습니다.
- Swagger 설정에 `public`, `admin` 그룹을 정리하고, 그룹 문서에서도 `bearerAuth` 보안 스킴이 노출되도록 수정했습니다.
- 프론트/백엔드 계약 차이는 `run/docs/swagger-contract-gaps.md`에 별도 메모로 남겼습니다.

## 확인 사항
- 런타임 API 로직은 변경하지 않았고 Swagger 메타데이터와 문서 설정만 수정했습니다.
- `./gradlew compileJava` 성공

## 기대 효과
- 프론트 화면 기준으로 Swagger에서 요청/응답 구조를 더 쉽게 확인할 수 있습니다.
- Swagger UI의 `Authorize` 버튼에서 access token을 입력해 인증이 필요한 API를 바로 테스트할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * API 문서화 설정을 정리하고 보안 구성을 간소화했습니다. 인증 스킴 등록 로직을 통합하여 코드 유지보수성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->