### PR TITLE
feat: 토스 링크페이 결제완료 웹훅 문자 발송 추가

### DIFF
--- a/run/src/main/java/com/guide/run/global/config/AsyncConfig.java
+++ b/run/src/main/java/com/guide/run/global/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.guide.run.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "tossWebhookTaskExecutor")
+    public ThreadPoolTaskExecutor tossWebhookTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("toss-webhook-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
+++ b/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
         return web -> {
             web.ignoring()
                     .requestMatchers("/health")
+                    .requestMatchers("/webhook/tosspayments")
                     .requestMatchers("/favicon.ico")
                     .requestMatchers("/member-upload")
                     .requestMatchers("/event-upload")

--- a/run/src/main/java/com/guide/run/global/sms/cool/WebhookCoolSmsService.java
+++ b/run/src/main/java/com/guide/run/global/sms/cool/WebhookCoolSmsService.java
@@ -1,0 +1,74 @@
+package com.guide.run.global.sms.cool;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+public class WebhookCoolSmsService {
+
+    @Value("${spring.coolsms.webhook-sms.from-number}")
+    private String fromNumber;
+
+    @Value("${spring.coolsms.webhook-sms.api-key}")
+    private String apiKey;
+
+    @Value("${spring.coolsms.webhook-sms.api-secret}")
+    private String apiSecret;
+
+    private DefaultMessageService messageService;
+
+    @PostConstruct
+    private void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    }
+
+    public void sendPaymentCompletedMessage(String to, String customerName) {
+        String normalizedTo = normalizePhoneNumber(to);
+        if (!StringUtils.hasText(normalizedTo)) {
+            log.warn("Skip webhook sms because customer phone number is invalid. phoneNumber={}", to);
+            return;
+        }
+
+        try {
+            Message message = new Message();
+            message.setFrom(fromNumber);
+            message.setTo(normalizedTo);
+            message.setAutoTypeDetect(true);
+            message.setText(buildMessageText(customerName));
+
+            messageService.sendOne(new SingleMessageSendingRequest(message));
+        } catch (Exception e) {
+            log.error("Failed to send webhook sms. to={}", normalizedTo, e);
+        }
+    }
+
+    String normalizePhoneNumber(String phoneNumber) {
+        if (!StringUtils.hasText(phoneNumber)) {
+            return null;
+        }
+
+        String normalized = phoneNumber.replaceAll("[^0-9]", "");
+        return StringUtils.hasText(normalized) ? normalized : null;
+    }
+
+    String buildMessageText(String customerName) {
+        String firstLine = StringUtils.hasText(customerName)
+                ? customerName.trim() + "님 회비 납부를 완료해주셔서 감사합니다."
+                : "안녕하세요, 가이드런프로젝트입니다.";
+
+        return firstLine + "\n"
+                + "아래 링크를 통해 정회원 오픈채팅방에 입장해주세요.\n"
+                + "*입장 시 대화명은 본인 성함으로 바꿔서 입장!\n"
+                + "\n"
+                + "비밀번호[ 0401 ]\n"
+                + "https://open.kakao.com/o/gLM7V1ni";
+    }
+}

--- a/run/src/main/java/com/guide/run/global/sms/cool/WebhookCoolSmsService.java
+++ b/run/src/main/java/com/guide/run/global/sms/cool/WebhookCoolSmsService.java
@@ -14,6 +14,8 @@ import org.springframework.util.StringUtils;
 @Service
 public class WebhookCoolSmsService {
 
+    private static final String WEBHOOK_SMS_SUBJECT = "[가이드런프로젝트] 오픈채팅방 입장 안내";
+
     @Value("${spring.coolsms.webhook-sms.from-number}")
     private String fromNumber;
 
@@ -42,6 +44,7 @@ public class WebhookCoolSmsService {
             message.setFrom(fromNumber);
             message.setTo(normalizedTo);
             message.setAutoTypeDetect(true);
+            message.setSubject(WEBHOOK_SMS_SUBJECT);
             message.setText(buildMessageText(customerName));
 
             messageService.sendOne(new SingleMessageSendingRequest(message));

--- a/run/src/main/java/com/guide/run/global/webhook/tosspayments/controller/TossPaymentsWebhookController.java
+++ b/run/src/main/java/com/guide/run/global/webhook/tosspayments/controller/TossPaymentsWebhookController.java
@@ -22,8 +22,6 @@ public class TossPaymentsWebhookController {
 
     @PostMapping("/webhook/tosspayments")
     public ResponseEntity<Void> receiveWebhook(@RequestBody(required = false) TossPaymentsWebhookRequest request) {
-        log.info("Received tosspayments webhook payload: {}", request);
-
         if (shouldProcess(request)) {
             try {
                 tossPaymentsWebhookAsyncService.processPaymentCompleted(

--- a/run/src/main/java/com/guide/run/global/webhook/tosspayments/controller/TossPaymentsWebhookController.java
+++ b/run/src/main/java/com/guide/run/global/webhook/tosspayments/controller/TossPaymentsWebhookController.java
@@ -1,0 +1,49 @@
+package com.guide.run.global.webhook.tosspayments.controller;
+
+import com.guide.run.global.webhook.tosspayments.dto.TossPaymentsWebhookRequest;
+import com.guide.run.global.webhook.tosspayments.service.TossPaymentsWebhookAsyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class TossPaymentsWebhookController {
+
+    private static final String PAYMENT_STATUS_CHANGED = "PAYMENT_STATUS_CHANGED";
+    private static final String DONE = "DONE";
+
+    private final TossPaymentsWebhookAsyncService tossPaymentsWebhookAsyncService;
+
+    @PostMapping("/webhook/tosspayments")
+    public ResponseEntity<Void> receiveWebhook(@RequestBody(required = false) TossPaymentsWebhookRequest request) {
+        log.info("Received tosspayments webhook payload: {}", request);
+
+        if (shouldProcess(request)) {
+            try {
+                tossPaymentsWebhookAsyncService.processPaymentCompleted(
+                        request.getData().getPaymentKey(),
+                        request.getData().getOrderId()
+                );
+            } catch (Exception e) {
+                log.error("Failed to dispatch tosspayments webhook async task. orderId={}",
+                        request.getData().getOrderId(), e);
+            }
+        }
+
+        return ResponseEntity.ok().build();
+    }
+
+    private boolean shouldProcess(TossPaymentsWebhookRequest request) {
+        return request != null
+                && PAYMENT_STATUS_CHANGED.equals(request.getEventType())
+                && request.getData() != null
+                && DONE.equals(request.getData().getStatus())
+                && StringUtils.hasText(request.getData().getOrderId());
+    }
+}

--- a/run/src/main/java/com/guide/run/global/webhook/tosspayments/dto/TossPaymentCustomerInfo.java
+++ b/run/src/main/java/com/guide/run/global/webhook/tosspayments/dto/TossPaymentCustomerInfo.java
@@ -1,0 +1,11 @@
+package com.guide.run.global.webhook.tosspayments.dto;
+
+public record TossPaymentCustomerInfo(
+        String paymentKey,
+        String orderId,
+        String orderName,
+        Long totalAmount,
+        String customerName,
+        String customerPhone
+) {
+}

--- a/run/src/main/java/com/guide/run/global/webhook/tosspayments/dto/TossPaymentsWebhookRequest.java
+++ b/run/src/main/java/com/guide/run/global/webhook/tosspayments/dto/TossPaymentsWebhookRequest.java
@@ -1,0 +1,26 @@
+package com.guide.run.global.webhook.tosspayments.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class TossPaymentsWebhookRequest {
+    private String eventType;
+    private String createdAt;
+    private WebhookData data;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @ToString
+    public static class WebhookData {
+        private String paymentKey;
+        private String status;
+        private String orderId;
+    }
+}

--- a/run/src/main/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsOrderService.java
+++ b/run/src/main/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsOrderService.java
@@ -1,11 +1,8 @@
 package com.guide.run.global.webhook.tosspayments.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.guide.run.global.webhook.tosspayments.dto.TossPaymentCustomerInfo;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -19,15 +16,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TossPaymentsOrderService {
 
-    private static final String ORDER_LOOKUP_URL = "https://api.tosspayments.com/v1/payments/orders/{orderId}";
+    private static final String ORDER_LOOKUP_URL = "https://linkpay-openapi.tosspayments.com/api/v1/orders/{orderId}";
 
     private final RestTemplate restTemplate;
-    private final ObjectMapper objectMapper;
 
     @Value("${spring.tosspayments.secret-key}")
     private String secretKey;
@@ -49,24 +44,27 @@ public class TossPaymentsOrderService {
             throw new IllegalStateException("TossPayments payment response body is empty.");
         }
 
-        log.info("TossPayments order lookup response. orderId={}, statusCode={}, body={}",
-                orderId,
-                response.getStatusCode(),
-                maskSensitiveFields(body));
+        JsonNode resultNode = body.path("result");
+        if (resultNode.isMissingNode() || resultNode.isNull() || resultNode.isEmpty()) {
+            throw new IllegalStateException("LinkPay order lookup result is empty.");
+        }
 
         return new TossPaymentCustomerInfo(
-                readText(body, "/paymentKey"),
-                readText(body, "/orderId"),
-                readText(body, "/orderName"),
-                readLong(body, "/totalAmount"),
-                firstText(body, List.of("/customerName", "/customer/name")),
+                readText(resultNode, "/paymentKey"),
+                readText(resultNode, "/orderId"),
+                firstText(resultNode, List.of(
+                        "/orderItems/0/product/name",
+                        "/product/name",
+                        "/orderName"
+                )),
+                firstLong(resultNode, List.of("/amount", "/totalAmount")),
+                firstText(resultNode, List.of("/customerName", "/customer/name")),
                 firstText(body, List.of(
-                        "/mobilePhone/customerMobilePhone",
-                        "/customerMobilePhone",
-                        "/mobilePhone",
-                        "/customer/mobilePhone",
-                        "/customerPhone",
-                        "/phone"
+                        "/result/customerPhoneNumber",
+                        "/result/phoneNumber",
+                        "/result/customerPhone",
+                        "/result/mobilePhone",
+                        "/result/shipping/phoneNumber"
                 ))
         );
     }
@@ -106,11 +104,13 @@ public class TossPaymentsOrderService {
         return node.asLong();
     }
 
-    private JsonNode maskSensitiveFields(JsonNode body) {
-        JsonNode copied = body.deepCopy();
-        if (copied instanceof ObjectNode objectNode && objectNode.has("secret")) {
-            objectNode.put("secret", "***");
+    private Long firstLong(JsonNode body, List<String> jsonPointers) {
+        for (String jsonPointer : jsonPointers) {
+            Long value = readLong(body, jsonPointer);
+            if (value != null) {
+                return value;
+            }
         }
-        return copied;
+        return null;
     }
 }

--- a/run/src/main/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsOrderService.java
+++ b/run/src/main/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsOrderService.java
@@ -1,0 +1,116 @@
+package com.guide.run.global.webhook.tosspayments.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.guide.run.global.webhook.tosspayments.dto.TossPaymentCustomerInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TossPaymentsOrderService {
+
+    private static final String ORDER_LOOKUP_URL = "https://api.tosspayments.com/v1/payments/orders/{orderId}";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${spring.tosspayments.secret-key}")
+    private String secretKey;
+
+    public TossPaymentCustomerInfo getPaymentByOrderId(String orderId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, createAuthorizationHeader());
+
+        ResponseEntity<JsonNode> response = restTemplate.exchange(
+                ORDER_LOOKUP_URL,
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                JsonNode.class,
+                orderId
+        );
+
+        JsonNode body = response.getBody();
+        if (body == null) {
+            throw new IllegalStateException("TossPayments payment response body is empty.");
+        }
+
+        log.info("TossPayments order lookup response. orderId={}, statusCode={}, body={}",
+                orderId,
+                response.getStatusCode(),
+                maskSensitiveFields(body));
+
+        return new TossPaymentCustomerInfo(
+                readText(body, "/paymentKey"),
+                readText(body, "/orderId"),
+                readText(body, "/orderName"),
+                readLong(body, "/totalAmount"),
+                firstText(body, List.of("/customerName", "/customer/name")),
+                firstText(body, List.of(
+                        "/mobilePhone/customerMobilePhone",
+                        "/customerMobilePhone",
+                        "/mobilePhone",
+                        "/customer/mobilePhone",
+                        "/customerPhone",
+                        "/phone"
+                ))
+        );
+    }
+
+    private String createAuthorizationHeader() {
+        String credentials = secretKey + ":";
+        String encoded = Base64.getEncoder()
+                .encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + encoded;
+    }
+
+    private String firstText(JsonNode body, List<String> jsonPointers) {
+        for (String jsonPointer : jsonPointers) {
+            String value = readText(body, jsonPointer);
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private String readText(JsonNode body, String jsonPointer) {
+        JsonNode node = body.at(jsonPointer);
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+
+        String value = node.asText();
+        return StringUtils.hasText(value) ? value : null;
+    }
+
+    private Long readLong(JsonNode body, String jsonPointer) {
+        JsonNode node = body.at(jsonPointer);
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        return node.asLong();
+    }
+
+    private JsonNode maskSensitiveFields(JsonNode body) {
+        JsonNode copied = body.deepCopy();
+        if (copied instanceof ObjectNode objectNode && objectNode.has("secret")) {
+            objectNode.put("secret", "***");
+        }
+        return copied;
+    }
+}

--- a/run/src/main/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsWebhookAsyncService.java
+++ b/run/src/main/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsWebhookAsyncService.java
@@ -8,17 +8,12 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-import java.util.List;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TossPaymentsWebhookAsyncService {
 
-    private static final List<String> SMS_ALLOWED_ORDER_NAME_KEYWORDS = List.of(
-            "정회원 회비 납부",
-            "테스트"
-    );
+    private static final String MEMBERSHIP_FEE_ORDER_NAME_KEYWORD = "정회원 회비 납부";
 
     private final TossPaymentsOrderService tossPaymentsOrderService;
     private final WebhookCoolSmsService webhookCoolSmsService;
@@ -52,6 +47,6 @@ public class TossPaymentsWebhookAsyncService {
 
     private boolean isMembershipFeePayment(String orderName) {
         return StringUtils.hasText(orderName)
-                && SMS_ALLOWED_ORDER_NAME_KEYWORDS.stream().anyMatch(orderName::contains);
+                && orderName.contains(MEMBERSHIP_FEE_ORDER_NAME_KEYWORD);
     }
 }

--- a/run/src/main/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsWebhookAsyncService.java
+++ b/run/src/main/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsWebhookAsyncService.java
@@ -1,0 +1,57 @@
+package com.guide.run.global.webhook.tosspayments.service;
+
+import com.guide.run.global.sms.cool.WebhookCoolSmsService;
+import com.guide.run.global.webhook.tosspayments.dto.TossPaymentCustomerInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TossPaymentsWebhookAsyncService {
+
+    private static final List<String> SMS_ALLOWED_ORDER_NAME_KEYWORDS = List.of(
+            "정회원 회비 납부",
+            "테스트"
+    );
+
+    private final TossPaymentsOrderService tossPaymentsOrderService;
+    private final WebhookCoolSmsService webhookCoolSmsService;
+
+    @Async("tossWebhookTaskExecutor")
+    public void processPaymentCompleted(String paymentKey, String orderId) {
+        try {
+            TossPaymentCustomerInfo paymentInfo = tossPaymentsOrderService.getPaymentByOrderId(orderId);
+            String resolvedPaymentKey = StringUtils.hasText(paymentInfo.paymentKey())
+                    ? paymentInfo.paymentKey() : paymentKey;
+
+            if (!isMembershipFeePayment(paymentInfo.orderName())) {
+                log.info("Skip webhook sms because order is not membership fee. paymentKey={}, orderId={}, orderName={}",
+                        resolvedPaymentKey, orderId, paymentInfo.orderName());
+                return;
+            }
+
+            if (!StringUtils.hasText(paymentInfo.customerPhone())) {
+                log.warn("Customer phone number not found. paymentKey={}, orderId={}", resolvedPaymentKey, orderId);
+                return;
+            }
+
+            webhookCoolSmsService.sendPaymentCompletedMessage(
+                    paymentInfo.customerPhone(),
+                    paymentInfo.customerName()
+            );
+        } catch (Exception e) {
+            log.error("Failed to process tosspayments webhook. paymentKey={}, orderId={}", paymentKey, orderId, e);
+        }
+    }
+
+    private boolean isMembershipFeePayment(String orderName) {
+        return StringUtils.hasText(orderName)
+                && SMS_ALLOWED_ORDER_NAME_KEYWORDS.stream().anyMatch(orderName::contains);
+    }
+}

--- a/run/src/main/resources/application-batch.yml
+++ b/run/src/main/resources/application-batch.yml
@@ -53,6 +53,8 @@ spring:
       api-key: ${COOLSMS_WEBHOOK_API_KEY}
       api-secret: ${COOLSMS_WEBHOOK_API_SECRET}
       from-number: ${SEND_NUMBER}
+  tosspayments:
+    secret-key: ${TOSSPAYMENTS_SECRET_KEY}
 cors:
   origin: https://guiderun.org
 

--- a/run/src/main/resources/application-batch.yml
+++ b/run/src/main/resources/application-batch.yml
@@ -49,6 +49,10 @@ spring:
     kakaoChId: ${KAKAO_CH_ID}
     signupCompletionMsgId: ${SIGNUP_COMPLETE_MSG}
     signupApprovalMsgId: ${SIGNUP_APPROVAL_MSG}
+    webhook-sms:
+      api-key: ${COOLSMS_WEBHOOK_API_KEY}
+      api-secret: ${COOLSMS_WEBHOOK_API_SECRET}
+      from-number: ${SEND_NUMBER}
 cors:
   origin: https://guiderun.org
 

--- a/run/src/main/resources/application-dev.yml
+++ b/run/src/main/resources/application-dev.yml
@@ -50,6 +50,10 @@ spring:
     kakaoChId: ${KAKAO_CH_ID}
     signupCompletionMsgId: ${SIGNUP_COMPLETE_MSG}
     signupApprovalMsgId: ${SIGNUP_APPROVAL_MSG}
+    webhook-sms:
+      api-key: ${COOLSMS_WEBHOOK_API_KEY}
+      api-secret: ${COOLSMS_WEBHOOK_API_SECRET}
+      from-number: ${SEND_NUMBER}
 cors:
   origin: https://dev.guiderun.org
 

--- a/run/src/main/resources/application-dev.yml
+++ b/run/src/main/resources/application-dev.yml
@@ -54,6 +54,8 @@ spring:
       api-key: ${COOLSMS_WEBHOOK_API_KEY}
       api-secret: ${COOLSMS_WEBHOOK_API_SECRET}
       from-number: ${SEND_NUMBER}
+  tosspayments:
+    secret-key: ${TOSSPAYMENTS_SECRET_KEY}
 cors:
   origin: https://dev.guiderun.org
 

--- a/run/src/main/resources/application-local.yml
+++ b/run/src/main/resources/application-local.yml
@@ -54,6 +54,8 @@ spring:
       api-key: ${COOLSMS_WEBHOOK_API_KEY}
       api-secret: ${COOLSMS_WEBHOOK_API_SECRET}
       from-number: ${SEND_NUMBER}
+  tosspayments:
+    secret-key: ${TOSSPAYMENTS_SECRET_KEY}
 
 cors:
   allowed-origins:

--- a/run/src/main/resources/application-local.yml
+++ b/run/src/main/resources/application-local.yml
@@ -58,7 +58,7 @@ spring:
     secret-key: ${TOSSPAYMENTS_SECRET_KEY}
 
 cors:
-  allowed-origins:
+  origin: http://localhost:3000
 
 cloud:
   aws:

--- a/run/src/main/resources/application-local.yml
+++ b/run/src/main/resources/application-local.yml
@@ -50,6 +50,10 @@ spring:
     kakaoChId: ${KAKAO_CH_ID}
     signupCompletionMsgId: ${SIGNUP_COMPLETE_MSG}
     signupApprovalMsgId: ${SIGNUP_APPROVAL_MSG}
+    webhook-sms:
+      api-key: ${COOLSMS_WEBHOOK_API_KEY}
+      api-secret: ${COOLSMS_WEBHOOK_API_SECRET}
+      from-number: ${SEND_NUMBER}
 
 cors:
   allowed-origins:

--- a/run/src/main/resources/application-prod.yml
+++ b/run/src/main/resources/application-prod.yml
@@ -53,6 +53,8 @@ spring:
       api-key: ${COOLSMS_WEBHOOK_API_KEY}
       api-secret: ${COOLSMS_WEBHOOK_API_SECRET}
       from-number: ${SEND_NUMBER}
+  tosspayments:
+    secret-key: ${TOSSPAYMENTS_SECRET_KEY}
 cors:
   origin: https://guiderun.org
 

--- a/run/src/main/resources/application-prod.yml
+++ b/run/src/main/resources/application-prod.yml
@@ -49,6 +49,10 @@ spring:
     kakaoChId: ${KAKAO_CH_ID}
     signupCompletionMsgId: ${SIGNUP_COMPLETE_MSG}
     signupApprovalMsgId: ${SIGNUP_APPROVAL_MSG}
+    webhook-sms:
+      api-key: ${COOLSMS_WEBHOOK_API_KEY}
+      api-secret: ${COOLSMS_WEBHOOK_API_SECRET}
+      from-number: ${SEND_NUMBER}
 cors:
   origin: https://guiderun.org
 

--- a/run/src/test/java/com/guide/run/global/sms/cool/WebhookCoolSmsServiceTest.java
+++ b/run/src/test/java/com/guide/run/global/sms/cool/WebhookCoolSmsServiceTest.java
@@ -1,0 +1,37 @@
+package com.guide.run.global.sms.cool;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebhookCoolSmsServiceTest {
+
+    private final WebhookCoolSmsService webhookCoolSmsService = new WebhookCoolSmsService();
+
+    @Test
+    @DisplayName("이름이 있으면 이름으로 시작하는 문자 문구를 만든다")
+    void buildMessageTextUsesCustomerName() {
+        String message = webhookCoolSmsService.buildMessageText("홍길동");
+
+        assertThat(message).startsWith("홍길동님 회비 납부를 완료해주셔서 감사합니다.");
+        assertThat(message).contains("https://open.kakao.com/o/gLM7V1ni");
+    }
+
+    @Test
+    @DisplayName("이름이 없으면 기본 안내 문구로 시작한다")
+    void buildMessageTextUsesDefaultGreeting() {
+        String message = webhookCoolSmsService.buildMessageText(null);
+
+        assertThat(message).startsWith("안녕하세요, 가이드런프로젝트입니다.");
+        assertThat(message).contains("비밀번호[ 0401 ]");
+    }
+
+    @Test
+    @DisplayName("전화번호는 숫자만 남기도록 정규화한다")
+    void normalizePhoneNumberRemovesNonDigits() {
+        String normalized = webhookCoolSmsService.normalizePhoneNumber("010-1234-5678");
+
+        assertThat(normalized).isEqualTo("01012345678");
+    }
+}

--- a/run/src/test/java/com/guide/run/global/webhook/tosspayments/controller/TossPaymentsWebhookControllerTest.java
+++ b/run/src/test/java/com/guide/run/global/webhook/tosspayments/controller/TossPaymentsWebhookControllerTest.java
@@ -1,0 +1,121 @@
+package com.guide.run.global.webhook.tosspayments.controller;
+
+import com.guide.run.global.webhook.tosspayments.service.TossPaymentsWebhookAsyncService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TossPaymentsWebhookControllerTest {
+
+    @Mock
+    private TossPaymentsWebhookAsyncService tossPaymentsWebhookAsyncService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        TossPaymentsWebhookController controller =
+                new TossPaymentsWebhookController(tossPaymentsWebhookAsyncService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    @DisplayName("PAYMENT_STATUS_CHANGED DONE 웹훅은 비동기 처리로 넘긴다")
+    void receiveWebhookDispatchesAsyncTask() throws Exception {
+        mockMvc.perform(post("/webhook/tosspayments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "eventType": "PAYMENT_STATUS_CHANGED",
+                                  "createdAt": "2022-05-12T00:00:00.000",
+                                  "data": {
+                                    "paymentKey": "payment-key",
+                                    "status": "DONE",
+                                    "orderId": "order-123"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        verify(tossPaymentsWebhookAsyncService).processPaymentCompleted("payment-key", "order-123");
+    }
+
+    @Test
+    @DisplayName("처리 대상이 아닌 웹훅도 200을 반환하고 무시한다")
+    void receiveWebhookIgnoresNonTargetEvent() throws Exception {
+        mockMvc.perform(post("/webhook/tosspayments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "eventType": "PAYMENT_CANCELED",
+                                  "createdAt": "2022-05-12T00:00:00.000",
+                                  "data": {
+                                    "paymentKey": "payment-key",
+                                    "status": "DONE",
+                                    "orderId": "order-123"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        verifyNoInteractions(tossPaymentsWebhookAsyncService);
+    }
+
+    @Test
+    @DisplayName("orderId가 없으면 200을 반환하고 무시한다")
+    void receiveWebhookReturnsOkWhenOrderIdMissing() throws Exception {
+        mockMvc.perform(post("/webhook/tosspayments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "eventType": "PAYMENT_STATUS_CHANGED",
+                                  "createdAt": "2022-05-12T00:00:00.000",
+                                  "data": {
+                                    "paymentKey": "payment-key",
+                                    "status": "DONE",
+                                    "orderId": ""
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        verifyNoInteractions(tossPaymentsWebhookAsyncService);
+    }
+
+    @Test
+    @DisplayName("비동기 작업 디스패치가 실패해도 200을 반환한다")
+    void receiveWebhookReturnsOkWhenAsyncDispatchFails() throws Exception {
+        doThrow(new TaskRejectedException("queue is full"))
+                .when(tossPaymentsWebhookAsyncService)
+                .processPaymentCompleted("payment-key", "order-123");
+
+        mockMvc.perform(post("/webhook/tosspayments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "eventType": "PAYMENT_STATUS_CHANGED",
+                                  "createdAt": "2022-05-12T00:00:00.000",
+                                  "data": {
+                                    "paymentKey": "payment-key",
+                                    "status": "DONE",
+                                    "orderId": "order-123"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk());
+    }
+}

--- a/run/src/test/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsOrderServiceTest.java
+++ b/run/src/test/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsOrderServiceTest.java
@@ -1,0 +1,91 @@
+package com.guide.run.global.webhook.tosspayments.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guide.run.global.webhook.tosspayments.dto.TossPaymentCustomerInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class TossPaymentsOrderServiceTest {
+
+    private RestTemplate restTemplate;
+    private MockRestServiceServer mockRestServiceServer;
+    private TossPaymentsOrderService tossPaymentsOrderService;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+        mockRestServiceServer = MockRestServiceServer.createServer(restTemplate);
+        objectMapper = new ObjectMapper();
+        tossPaymentsOrderService = new TossPaymentsOrderService(restTemplate, objectMapper);
+        ReflectionTestUtils.setField(tossPaymentsOrderService, "secretKey", "test_secret_key");
+    }
+
+    @Test
+    @DisplayName("orderId로 결제를 조회할 때 Basic 인증 헤더와 고객 정보를 파싱한다")
+    void getPaymentByOrderIdParsesCustomerInfo() {
+        String encoded = Base64.getEncoder()
+                .encodeToString("test_secret_key:".getBytes(StandardCharsets.UTF_8));
+
+        mockRestServiceServer.expect(requestTo("https://api.tosspayments.com/v1/payments/orders/order-123"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Basic " + encoded))
+                .andRespond(withSuccess("""
+                        {
+                          "paymentKey": "payment-key",
+                          "orderId": "order-123",
+                          "orderName": "정회원 회비",
+                          "totalAmount": 30000,
+                          "customerName": "홍길동",
+                          "mobilePhone": {
+                            "customerMobilePhone": "010-1234-5678"
+                          }
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        TossPaymentCustomerInfo payment = tossPaymentsOrderService.getPaymentByOrderId("order-123");
+
+        assertThat(payment.paymentKey()).isEqualTo("payment-key");
+        assertThat(payment.orderId()).isEqualTo("order-123");
+        assertThat(payment.orderName()).isEqualTo("정회원 회비");
+        assertThat(payment.totalAmount()).isEqualTo(30000L);
+        assertThat(payment.customerName()).isEqualTo("홍길동");
+        assertThat(payment.customerPhone()).isEqualTo("010-1234-5678");
+    }
+
+    @Test
+    @DisplayName("고객 전화번호가 없으면 null로 반환한다")
+    void getPaymentByOrderIdReturnsNullPhoneWhenMissing() {
+        mockRestServiceServer.expect(requestTo("https://api.tosspayments.com/v1/payments/orders/order-456"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        {
+                          "paymentKey": "payment-key",
+                          "orderId": "order-456",
+                          "orderName": "정회원 회비",
+                          "totalAmount": 30000,
+                          "customerName": "홍길동"
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        TossPaymentCustomerInfo payment = tossPaymentsOrderService.getPaymentByOrderId("order-456");
+
+        assertThat(payment.customerPhone()).isNull();
+    }
+}

--- a/run/src/test/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsOrderServiceTest.java
+++ b/run/src/test/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsOrderServiceTest.java
@@ -1,6 +1,5 @@
 package com.guide.run.global.webhook.tosspayments.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guide.run.global.webhook.tosspayments.dto.TossPaymentCustomerInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,14 +25,12 @@ class TossPaymentsOrderServiceTest {
     private RestTemplate restTemplate;
     private MockRestServiceServer mockRestServiceServer;
     private TossPaymentsOrderService tossPaymentsOrderService;
-    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
         restTemplate = new RestTemplate();
         mockRestServiceServer = MockRestServiceServer.createServer(restTemplate);
-        objectMapper = new ObjectMapper();
-        tossPaymentsOrderService = new TossPaymentsOrderService(restTemplate, objectMapper);
+        tossPaymentsOrderService = new TossPaymentsOrderService(restTemplate);
         ReflectionTestUtils.setField(tossPaymentsOrderService, "secretKey", "test_secret_key");
     }
 
@@ -43,18 +40,26 @@ class TossPaymentsOrderServiceTest {
         String encoded = Base64.getEncoder()
                 .encodeToString("test_secret_key:".getBytes(StandardCharsets.UTF_8));
 
-        mockRestServiceServer.expect(requestTo("https://api.tosspayments.com/v1/payments/orders/order-123"))
+        mockRestServiceServer.expect(requestTo("https://linkpay-openapi.tosspayments.com/api/v1/orders/order-123"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Basic " + encoded))
                 .andRespond(withSuccess("""
                         {
-                          "paymentKey": "payment-key",
-                          "orderId": "order-123",
-                          "orderName": "정회원 회비",
-                          "totalAmount": 30000,
-                          "customerName": "홍길동",
-                          "mobilePhone": {
-                            "customerMobilePhone": "010-1234-5678"
+                          "code": "SUCCESS",
+                          "message": "",
+                          "result": {
+                            "paymentKey": "payment-key",
+                            "orderId": "order-123",
+                            "amount": 30000,
+                            "customerName": "홍길동",
+                            "customerPhoneNumber": "010-1234-5678",
+                            "orderItems": [
+                              {
+                                "product": {
+                                  "name": "2026 상반기 정회원 회비 납부"
+                                }
+                              }
+                            ]
                           }
                         }
                         """, MediaType.APPLICATION_JSON));
@@ -63,7 +68,7 @@ class TossPaymentsOrderServiceTest {
 
         assertThat(payment.paymentKey()).isEqualTo("payment-key");
         assertThat(payment.orderId()).isEqualTo("order-123");
-        assertThat(payment.orderName()).isEqualTo("정회원 회비");
+        assertThat(payment.orderName()).isEqualTo("2026 상반기 정회원 회비 납부");
         assertThat(payment.totalAmount()).isEqualTo(30000L);
         assertThat(payment.customerName()).isEqualTo("홍길동");
         assertThat(payment.customerPhone()).isEqualTo("010-1234-5678");
@@ -72,20 +77,55 @@ class TossPaymentsOrderServiceTest {
     @Test
     @DisplayName("고객 전화번호가 없으면 null로 반환한다")
     void getPaymentByOrderIdReturnsNullPhoneWhenMissing() {
-        mockRestServiceServer.expect(requestTo("https://api.tosspayments.com/v1/payments/orders/order-456"))
+        mockRestServiceServer.expect(requestTo("https://linkpay-openapi.tosspayments.com/api/v1/orders/order-456"))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess("""
                         {
-                          "paymentKey": "payment-key",
-                          "orderId": "order-456",
-                          "orderName": "정회원 회비",
-                          "totalAmount": 30000,
-                          "customerName": "홍길동"
+                          "code": "SUCCESS",
+                          "message": "",
+                          "result": {
+                            "paymentKey": "payment-key",
+                            "orderId": "order-456",
+                            "amount": 30000,
+                            "customerName": "홍길동",
+                            "orderItems": [
+                              {
+                                "product": {
+                                  "name": "2026 상반기 정회원 회비 납부"
+                                }
+                              }
+                            ]
+                          }
                         }
                         """, MediaType.APPLICATION_JSON));
 
         TossPaymentCustomerInfo payment = tossPaymentsOrderService.getPaymentByOrderId("order-456");
 
         assertThat(payment.customerPhone()).isNull();
+    }
+
+    @Test
+    @DisplayName("orderItems 상품명이 없으면 orderName fallback을 사용한다")
+    void getPaymentByOrderIdFallsBackToOrderName() {
+        mockRestServiceServer.expect(requestTo("https://linkpay-openapi.tosspayments.com/api/v1/orders/order-789"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        {
+                          "code": "SUCCESS",
+                          "message": "",
+                          "result": {
+                            "paymentKey": "payment-key",
+                            "orderId": "order-789",
+                            "orderName": "테스트",
+                            "amount": 100,
+                            "customerName": "홍길동",
+                            "customerPhoneNumber": "01012345678"
+                          }
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        TossPaymentCustomerInfo payment = tossPaymentsOrderService.getPaymentByOrderId("order-789");
+
+        assertThat(payment.orderName()).isEqualTo("테스트");
     }
 }

--- a/run/src/test/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsWebhookAsyncServiceTest.java
+++ b/run/src/test/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsWebhookAsyncServiceTest.java
@@ -1,0 +1,133 @@
+package com.guide.run.global.webhook.tosspayments.service;
+
+import com.guide.run.global.sms.cool.WebhookCoolSmsService;
+import com.guide.run.global.webhook.tosspayments.dto.TossPaymentCustomerInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TossPaymentsWebhookAsyncServiceTest {
+
+    @Mock
+    private TossPaymentsOrderService tossPaymentsOrderService;
+
+    @Mock
+    private WebhookCoolSmsService webhookCoolSmsService;
+
+    @InjectMocks
+    private TossPaymentsWebhookAsyncService tossPaymentsWebhookAsyncService;
+
+    @Test
+    @DisplayName("고객 전화번호가 있으면 문자를 발송한다")
+    void processPaymentCompletedSendsSms() {
+        when(tossPaymentsOrderService.getPaymentByOrderId("order-123"))
+                .thenReturn(new TossPaymentCustomerInfo(
+                        "payment-key",
+                        "order-123",
+                        "2026 상반기 정회원 회비 납부",
+                        30000L,
+                        "홍길동",
+                        "010-1234-5678"
+                ));
+
+        tossPaymentsWebhookAsyncService.processPaymentCompleted("payment-key", "order-123");
+
+        verify(webhookCoolSmsService).sendPaymentCompletedMessage("010-1234-5678", "홍길동");
+    }
+
+    @Test
+    @DisplayName("테스트 상품명도 문자 발송을 허용한다")
+    void processPaymentCompletedSendsSmsForTestOrder() {
+        when(tossPaymentsOrderService.getPaymentByOrderId("order-123"))
+                .thenReturn(new TossPaymentCustomerInfo(
+                        "payment-key",
+                        "order-123",
+                        "테스트",
+                        30000L,
+                        "홍길동",
+                        "010-1234-5678"
+                ));
+
+        tossPaymentsWebhookAsyncService.processPaymentCompleted("payment-key", "order-123");
+
+        verify(webhookCoolSmsService).sendPaymentCompletedMessage("010-1234-5678", "홍길동");
+    }
+
+    @Test
+    @DisplayName("고객 전화번호가 없으면 문자 발송을 건너뛴다")
+    void processPaymentCompletedSkipsWhenPhoneMissing() {
+        when(tossPaymentsOrderService.getPaymentByOrderId("order-123"))
+                .thenReturn(new TossPaymentCustomerInfo(
+                        "payment-key",
+                        "order-123",
+                        "2026 상반기 정회원 회비 납부",
+                        30000L,
+                        "홍길동",
+                        null
+                ));
+
+        tossPaymentsWebhookAsyncService.processPaymentCompleted("payment-key", "order-123");
+
+        verifyNoInteractions(webhookCoolSmsService);
+    }
+
+    @Test
+    @DisplayName("토스 조회 실패 시 예외를 외부로 전파하지 않는다")
+    void processPaymentCompletedSwallowsLookupFailure() {
+        when(tossPaymentsOrderService.getPaymentByOrderId("order-123"))
+                .thenThrow(new RuntimeException("lookup failed"));
+
+        assertThatCode(() -> tossPaymentsWebhookAsyncService.processPaymentCompleted("payment-key", "order-123"))
+                .doesNotThrowAnyException();
+
+        verifyNoInteractions(webhookCoolSmsService);
+    }
+
+    @Test
+    @DisplayName("문자 발송 실패 시 예외를 외부로 전파하지 않는다")
+    void processPaymentCompletedSwallowsSmsFailure() {
+        when(tossPaymentsOrderService.getPaymentByOrderId("order-123"))
+                .thenReturn(new TossPaymentCustomerInfo(
+                        "payment-key",
+                        "order-123",
+                        "2026 상반기 정회원 회비 납부",
+                        30000L,
+                        "홍길동",
+                        "010-1234-5678"
+                ));
+        doThrow(new RuntimeException("sms failed"))
+                .when(webhookCoolSmsService)
+                .sendPaymentCompletedMessage("010-1234-5678", "홍길동");
+
+        assertThatCode(() -> tossPaymentsWebhookAsyncService.processPaymentCompleted("payment-key", "order-123"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("정회원 회비 상품이 아니면 문자 발송을 건너뛴다")
+    void processPaymentCompletedSkipsWhenOrderIsNotMembershipFee() {
+        when(tossPaymentsOrderService.getPaymentByOrderId("order-123"))
+                .thenReturn(new TossPaymentCustomerInfo(
+                        "payment-key",
+                        "order-123",
+                        "2026 상반기 10K PB 단축반 참가비",
+                        30000L,
+                        "홍길동",
+                        "010-1234-5678"
+                ));
+
+        tossPaymentsWebhookAsyncService.processPaymentCompleted("payment-key", "order-123");
+
+        verifyNoInteractions(webhookCoolSmsService);
+    }
+}

--- a/run/src/test/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsWebhookAsyncServiceTest.java
+++ b/run/src/test/java/com/guide/run/global/webhook/tosspayments/service/TossPaymentsWebhookAsyncServiceTest.java
@@ -46,24 +46,6 @@ class TossPaymentsWebhookAsyncServiceTest {
     }
 
     @Test
-    @DisplayName("테스트 상품명도 문자 발송을 허용한다")
-    void processPaymentCompletedSendsSmsForTestOrder() {
-        when(tossPaymentsOrderService.getPaymentByOrderId("order-123"))
-                .thenReturn(new TossPaymentCustomerInfo(
-                        "payment-key",
-                        "order-123",
-                        "테스트",
-                        30000L,
-                        "홍길동",
-                        "010-1234-5678"
-                ));
-
-        tossPaymentsWebhookAsyncService.processPaymentCompleted("payment-key", "order-123");
-
-        verify(webhookCoolSmsService).sendPaymentCompletedMessage("010-1234-5678", "홍길동");
-    }
-
-    @Test
     @DisplayName("고객 전화번호가 없으면 문자 발송을 건너뛴다")
     void processPaymentCompletedSkipsWhenPhoneMissing() {
         when(tossPaymentsOrderService.getPaymentByOrderId("order-123"))


### PR DESCRIPTION
## 변경 배경
- 토스 링크페이 결제 완료 시 웹훅 기반으로 문자 발송 흐름을 추가했습니다.

## 주요 변경 사항
- `/webhook/tosspayments` 공개 엔드포인트 추가 및 비동기 처리 구성
- `orderId` 기반 토스 결제 조회 서비스 추가
- 웹훅 전용 CoolSMS 발송 서비스 추가
- 정회원 회비/테스트 상품명 필터 추가
- 로컬 실행용 `cors.origin` 설정 보완

## 검증
- `./gradlew test --tests 'com.guide.run.global.webhook.tosspayments.controller.TossPaymentsWebhookControllerTest' --tests 'com.guide.run.global.webhook.tosspayments.service.TossPaymentsOrderServiceTest' --tests 'com.guide.run.global.webhook.tosspayments.service.TossPaymentsWebhookAsyncServiceTest' --tests 'com.guide.run.global.sms.cool.WebhookCoolSmsServiceTest'` 통과
- `./gradlew compileJava` 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 정회원 회비 납부 완료 시 고객에게 자동 SMS 알림 발송 기능 추가

* **Tests**
  * 결제 처리 및 SMS 알림 기능 관련 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->