### PR TITLE
feat: AppSmith 회원 승인 웹훅 추가

### DIFF
--- a/run/src/main/java/com/guide/run/admin/dto/response/UserApprovalResult.java
+++ b/run/src/main/java/com/guide/run/admin/dto/response/UserApprovalResult.java
@@ -1,0 +1,11 @@
+package com.guide.run.admin.dto.response;
+
+import com.guide.run.user.entity.type.Role;
+
+public record UserApprovalResult(
+        String userId,
+        Role role,
+        String recordDegree,
+        boolean changed
+) {
+}

--- a/run/src/main/java/com/guide/run/admin/service/AdminUserService.java
+++ b/run/src/main/java/com/guide/run/admin/service/AdminUserService.java
@@ -3,16 +3,15 @@ package com.guide.run.admin.service;
 import com.guide.run.admin.dto.condition.UserSortCond;
 import com.guide.run.admin.dto.request.ApproveRequest;
 import com.guide.run.admin.dto.response.GuideApplyResponse;
+import com.guide.run.admin.dto.response.UserApprovalResult;
 import com.guide.run.admin.dto.response.UserApprovalResponse;
 import com.guide.run.admin.dto.response.ViApplyResponse;
 import com.guide.run.admin.dto.response.user.NewUserResponse;
 import com.guide.run.admin.dto.response.user.UserItem;
 import com.guide.run.event.entity.dto.response.get.Count;
 import com.guide.run.global.exception.user.resource.NotExistUserException;
-import com.guide.run.global.sms.cool.CoolSmsService;
 import com.guide.run.user.entity.ArchiveData;
 import com.guide.run.user.entity.type.Role;
-import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.entity.user.Guide;
 import com.guide.run.user.entity.user.User;
 import com.guide.run.user.entity.user.Vi;
@@ -22,8 +21,10 @@ import com.guide.run.user.repository.ViRepository;
 import com.guide.run.user.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -35,7 +36,7 @@ public class AdminUserService {
     private final ViRepository viRepository;
     private final GuideRepository guideRepository;
     private final ArchiveDataRepository archiveDataRepository;
-    private final CoolSmsService coolSmsService;
+    private final UserApprovalService userApprovalService;
 
     public List<UserItem> getUserList(int start, int limit, UserSortCond cond){
        List<UserItem> response =  userRepository.sortAdminUser(start, limit, cond);
@@ -106,29 +107,24 @@ public class AdminUserService {
     //todo : 승인 후 회원에게 알림톡 전송
     @Transactional
     public UserApprovalResponse approveUser(String userId, ApproveRequest request){
-        User user = userRepository.findUserByUserId(userId).orElseThrow(NotExistUserException::new);
-        Boolean isApprove = false;
-        if(request.getIsApprove()){
-            user.approveUser(Role.ROLE_USER, request.getRecordDegree());
-            userRepository.save(user);
-            isApprove = true;
-        }else{
-            user.approveUser(Role.ROLE_REJECT, user.getRecordDegree());
-            userRepository.save(user);
+        if (request == null || request.getIsApprove() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "isApprove is required.");
         }
 
-        if(isApprove){
-            if(user.getType().equals(UserType.GUIDE)){
-                coolSmsService.sendToNewUser(user.getPhoneNumber(), user.getName(),"가이드러너", user.getRecordDegree());
-            } else if (user.getType().equals(UserType.VI)) {
-                coolSmsService.sendToNewUser(user.getPhoneNumber(), user.getName(),"시각장애러너", user.getRecordDegree());
-            }
-        }
+        Role targetRole = request.getIsApprove()
+                ? Role.ROLE_USER
+                : Role.ROLE_REJECT;
+        UserApprovalResult result = userApprovalService.processUserApproval(
+                userId,
+                targetRole,
+                request.getRecordDegree(),
+                "admin"
+        );
 
         UserApprovalResponse response = UserApprovalResponse.builder()
-                .userId(user.getUserId())
-                .isApprove(isApprove)
-                .recordDegree(user.getRecordDegree())
+                .userId(result.userId())
+                .isApprove(targetRole == Role.ROLE_USER)
+                .recordDegree(result.recordDegree())
                 .build();
         return response;
     }

--- a/run/src/main/java/com/guide/run/admin/service/UserApprovalService.java
+++ b/run/src/main/java/com/guide/run/admin/service/UserApprovalService.java
@@ -1,0 +1,92 @@
+package com.guide.run.admin.service;
+
+import com.guide.run.admin.dto.response.UserApprovalResult;
+import com.guide.run.global.exception.user.resource.NotExistUserException;
+import com.guide.run.global.sms.cool.CoolSmsService;
+import com.guide.run.user.entity.type.Role;
+import com.guide.run.user.entity.type.UserType;
+import com.guide.run.user.entity.user.User;
+import com.guide.run.user.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserApprovalService {
+
+    private final UserRepository userRepository;
+    private final CoolSmsService coolSmsService;
+
+    @Transactional
+    public UserApprovalResult processUserApproval(
+            String userId,
+            Role targetRole,
+            String recordDegree,
+            String requestedBy
+    ) {
+        validateRequest(userId, targetRole);
+
+        User user = userRepository.findUserByUserId(userId).orElseThrow(NotExistUserException::new);
+        Role previousRole = user.getRole();
+        String resolvedRecordDegree = StringUtils.hasText(recordDegree) ? recordDegree : user.getRecordDegree();
+
+        if (previousRole == targetRole && valuesEqual(user.getRecordDegree(), resolvedRecordDegree)) {
+            log.info("Skip user approval because user already has requested values. userId={}, role={}, requestedBy={}",
+                    userId, targetRole, requestedBy);
+            return toResult(user, false);
+        }
+
+        user.approveUser(targetRole, resolvedRecordDegree);
+        userRepository.save(user);
+
+        if (shouldSendApprovalMessage(previousRole, targetRole)) {
+            sendApprovalMessage(user);
+        }
+
+        log.info("Processed user approval. userId={}, previousRole={}, targetRole={}, requestedBy={}",
+                userId, previousRole, targetRole, requestedBy);
+        return toResult(user, true);
+    }
+
+    private void validateRequest(String userId, Role targetRole) {
+        if (!StringUtils.hasText(userId) || targetRole == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "userId and role are required.");
+        }
+    }
+
+    private boolean shouldSendApprovalMessage(Role previousRole, Role targetRole) {
+        return previousRole == Role.ROLE_WAIT
+                && targetRole != Role.ROLE_WAIT
+                && targetRole != Role.ROLE_REJECT;
+    }
+
+    private boolean valuesEqual(String left, String right) {
+        if (left == null) {
+            return right == null;
+        }
+        return left.equals(right);
+    }
+
+    private void sendApprovalMessage(User user) {
+        if (UserType.GUIDE.equals(user.getType())) {
+            coolSmsService.sendToNewUser(user.getPhoneNumber(), user.getName(), "가이드러너", user.getRecordDegree());
+        } else if (UserType.VI.equals(user.getType())) {
+            coolSmsService.sendToNewUser(user.getPhoneNumber(), user.getName(), "시각장애러너", user.getRecordDegree());
+        }
+    }
+
+    private UserApprovalResult toResult(User user, boolean changed) {
+        return new UserApprovalResult(
+                user.getUserId(),
+                user.getRole(),
+                user.getRecordDegree(),
+                changed
+        );
+    }
+}

--- a/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
+++ b/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
             web.ignoring()
                     .requestMatchers("/health")
                     .requestMatchers("/webhook/tosspayments")
+                    .requestMatchers("/webhook/appsmith/user-approval")
                     .requestMatchers("/favicon.ico")
                     .requestMatchers("/member-upload")
                     .requestMatchers("/event-upload")

--- a/run/src/main/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookController.java
+++ b/run/src/main/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookController.java
@@ -43,7 +43,7 @@ public class AppsmithUserApprovalWebhookController {
             @RequestHeader(value = SECRET_HEADER, required = false) String headerSecret,
             @RequestBody(required = false) AppsmithUserApprovalRequest request
     ) {
-        if (!isValidSecret(headerSecret, request)) {
+        if (!isValidSecret(headerSecret)) {
             return fail(HttpStatus.FORBIDDEN, "FORBIDDEN", "Invalid AppSmith webhook secret.");
         }
 
@@ -70,19 +70,21 @@ public class AppsmithUserApprovalWebhookController {
         return ResponseEntity.ok(response);
     }
 
-    private boolean isValidSecret(String headerSecret, AppsmithUserApprovalRequest request) {
-        String receivedSecret = StringUtils.hasText(headerSecret)
-                ? headerSecret
-                : request == null ? null : request.getSecret();
-
-        if (!StringUtils.hasText(webhookSecret) || !StringUtils.hasText(receivedSecret)) {
+    private boolean isValidSecret(String headerSecret) {
+        if (!StringUtils.hasText(webhookSecret) || !StringUtils.hasText(headerSecret)) {
+            log.warn("AppSmith webhook secret missing or not configured.");
             return false;
         }
 
-        return MessageDigest.isEqual(
+        boolean matches = MessageDigest.isEqual(
                 webhookSecret.getBytes(StandardCharsets.UTF_8),
-                receivedSecret.getBytes(StandardCharsets.UTF_8)
+                headerSecret.getBytes(StandardCharsets.UTF_8)
         );
+
+        if (!matches) {
+            log.warn("AppSmith webhook secret mismatch.");
+        }
+        return matches;
     }
 
     private ResponseEntity<FailResult> fail(HttpStatus status, String code, String message) {

--- a/run/src/main/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookController.java
+++ b/run/src/main/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookController.java
@@ -1,0 +1,122 @@
+package com.guide.run.global.webhook.appsmith.controller;
+
+import com.guide.run.admin.dto.response.UserApprovalResult;
+import com.guide.run.admin.service.UserApprovalService;
+import com.guide.run.global.dto.response.FailResult;
+import com.guide.run.global.webhook.appsmith.dto.AppsmithUserApprovalRequest;
+import com.guide.run.user.entity.type.Role;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+
+@Slf4j
+@RestController
+@CrossOrigin(origins = "*")
+public class AppsmithUserApprovalWebhookController {
+
+    private static final String SECRET_HEADER = "X-Appsmith-Webhook-Secret";
+
+    private final UserApprovalService userApprovalService;
+    private final String webhookSecret;
+
+    public AppsmithUserApprovalWebhookController(
+            UserApprovalService userApprovalService,
+            @Value("${spring.appsmith.webhook-secret}") String webhookSecret
+    ) {
+        this.userApprovalService = userApprovalService;
+        this.webhookSecret = webhookSecret;
+    }
+
+    @PostMapping("/webhook/appsmith/user-approval")
+    public ResponseEntity<?> approveUser(
+            @RequestHeader(value = SECRET_HEADER, required = false) String headerSecret,
+            @RequestBody(required = false) AppsmithUserApprovalRequest request
+    ) {
+        if (!isValidSecret(headerSecret, request)) {
+            return fail(HttpStatus.FORBIDDEN, "FORBIDDEN", "Invalid AppSmith webhook secret.");
+        }
+
+        if (request == null || !StringUtils.hasText(request.getUserId())) {
+            return fail(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "userId is required.");
+        }
+
+        Role targetRole = parseRole(request.getRole());
+        if (targetRole == null) {
+            return fail(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "role is required and must be valid.");
+        }
+
+        String recordDegree = request.getResolvedRecordDegree();
+        if (!StringUtils.hasText(recordDegree)) {
+            return fail(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "recordDegree is required.");
+        }
+
+        UserApprovalResult response = userApprovalService.processUserApproval(
+                request.getUserId(),
+                targetRole,
+                recordDegree,
+                request.getRequestedBy()
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    private boolean isValidSecret(String headerSecret, AppsmithUserApprovalRequest request) {
+        String receivedSecret = StringUtils.hasText(headerSecret)
+                ? headerSecret
+                : request == null ? null : request.getSecret();
+
+        if (!StringUtils.hasText(webhookSecret) || !StringUtils.hasText(receivedSecret)) {
+            return false;
+        }
+
+        return MessageDigest.isEqual(
+                webhookSecret.getBytes(StandardCharsets.UTF_8),
+                receivedSecret.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    private ResponseEntity<FailResult> fail(HttpStatus status, String code, String message) {
+        return ResponseEntity.status(status).body(new FailResult(code, message));
+    }
+
+    private Role parseRole(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        normalized = switch (normalized) {
+            case "대기중", "WAIT" -> "ROLE_WAIT";
+            case "거절", "반려", "REJECT" -> "ROLE_REJECT";
+            case "승인", "회원", "일반회원", "USER" -> "ROLE_USER";
+            case "코치", "COACH" -> "ROLE_COACH";
+            case "관리자", "ADMIN" -> "ROLE_ADMIN";
+            default -> normalized;
+        };
+
+        try {
+            Role role = Role.valueOf(normalized);
+            return isAppsmithManagedRole(role) ? role : null;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private boolean isAppsmithManagedRole(Role role) {
+        return role == Role.ROLE_WAIT
+                || role == Role.ROLE_REJECT
+                || role == Role.ROLE_USER
+                || role == Role.ROLE_COACH
+                || role == Role.ROLE_ADMIN;
+    }
+}

--- a/run/src/main/java/com/guide/run/global/webhook/appsmith/dto/AppsmithUserApprovalRequest.java
+++ b/run/src/main/java/com/guide/run/global/webhook/appsmith/dto/AppsmithUserApprovalRequest.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class AppsmithUserApprovalRequest {
-    private String secret;
     private String userId;
     private String role;
     private String recordDegree;

--- a/run/src/main/java/com/guide/run/global/webhook/appsmith/dto/AppsmithUserApprovalRequest.java
+++ b/run/src/main/java/com/guide/run/global/webhook/appsmith/dto/AppsmithUserApprovalRequest.java
@@ -1,0 +1,24 @@
+package com.guide.run.global.webhook.appsmith.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AppsmithUserApprovalRequest {
+    private String secret;
+    private String userId;
+    private String role;
+    private String recordDegree;
+    private String runningGroup;
+    private String requestedBy;
+
+    public String getResolvedRecordDegree() {
+        if (recordDegree != null && !recordDegree.isBlank()) {
+            return recordDegree;
+        }
+        return runningGroup;
+    }
+}

--- a/run/src/main/resources/application-batch.yml
+++ b/run/src/main/resources/application-batch.yml
@@ -55,6 +55,8 @@ spring:
       from-number: ${SEND_NUMBER}
   tosspayments:
     secret-key: ${TOSSPAYMENTS_SECRET_KEY}
+  appsmith:
+    webhook-secret: ${APPSMITH_WEBHOOK_SECRET}
 cors:
   origin: https://guiderun.org
 

--- a/run/src/main/resources/application-dev.yml
+++ b/run/src/main/resources/application-dev.yml
@@ -56,6 +56,8 @@ spring:
       from-number: ${SEND_NUMBER}
   tosspayments:
     secret-key: ${TOSSPAYMENTS_SECRET_KEY}
+  appsmith:
+    webhook-secret: ${APPSMITH_WEBHOOK_SECRET}
 cors:
   origin: https://dev.guiderun.org
 

--- a/run/src/main/resources/application-local.yml
+++ b/run/src/main/resources/application-local.yml
@@ -56,6 +56,8 @@ spring:
       from-number: ${SEND_NUMBER}
   tosspayments:
     secret-key: ${TOSSPAYMENTS_SECRET_KEY}
+  appsmith:
+    webhook-secret: ${APPSMITH_WEBHOOK_SECRET}
 
 cors:
   origin: http://localhost:3000

--- a/run/src/main/resources/application-prod.yml
+++ b/run/src/main/resources/application-prod.yml
@@ -55,6 +55,8 @@ spring:
       from-number: ${SEND_NUMBER}
   tosspayments:
     secret-key: ${TOSSPAYMENTS_SECRET_KEY}
+  appsmith:
+    webhook-secret: ${APPSMITH_WEBHOOK_SECRET}
 cors:
   origin: https://guiderun.org
 

--- a/run/src/test/java/com/guide/run/admin/service/UserApprovalServiceTest.java
+++ b/run/src/test/java/com/guide/run/admin/service/UserApprovalServiceTest.java
@@ -1,0 +1,128 @@
+package com.guide.run.admin.service;
+
+import com.guide.run.admin.dto.response.UserApprovalResult;
+import com.guide.run.global.sms.cool.CoolSmsService;
+import com.guide.run.user.entity.type.Role;
+import com.guide.run.user.entity.type.UserType;
+import com.guide.run.user.entity.user.User;
+import com.guide.run.user.repository.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserApprovalServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CoolSmsService coolSmsService;
+
+    @InjectMocks
+    private UserApprovalService userApprovalService;
+
+    @Test
+    @DisplayName("ROLE_WAIT 회원에게 거절이 아닌 권한을 부여하면 러닝그룹을 저장하고 승인 문자를 발송한다")
+    void processUserApprovalSendsSmsWhenWaitingUserGetsApprovedRole() {
+        User user = createUser(Role.ROLE_WAIT, UserType.GUIDE, "B");
+        when(userRepository.findUserByUserId("user-123")).thenReturn(Optional.of(user));
+
+        UserApprovalResult result = userApprovalService.processUserApproval(
+                "user-123",
+                Role.ROLE_USER,
+                "C그룹",
+                "admin@example.com"
+        );
+
+        assertThat(result.role()).isEqualTo(Role.ROLE_USER);
+        assertThat(result.recordDegree()).isEqualTo("C그룹");
+        assertThat(result.changed()).isTrue();
+        assertThat(user.getRole()).isEqualTo(Role.ROLE_USER);
+        assertThat(user.getRecordDegree()).isEqualTo("C그룹");
+        verify(userRepository).save(user);
+        verify(coolSmsService).sendToNewUser("01012345678", "홍길동", "가이드러너", "C그룹");
+    }
+
+    @Test
+    @DisplayName("ROLE_WAIT 회원을 ROLE_REJECT로 변경하면 러닝그룹은 저장하고 문자는 발송하지 않는다")
+    void processUserApprovalDoesNotSendSmsWhenWaitingUserGetsRejected() {
+        User user = createUser(Role.ROLE_WAIT, UserType.VI, "B");
+        when(userRepository.findUserByUserId("user-123")).thenReturn(Optional.of(user));
+
+        UserApprovalResult result = userApprovalService.processUserApproval(
+                "user-123",
+                Role.ROLE_REJECT,
+                "C그룹",
+                "admin@example.com"
+        );
+
+        assertThat(result.role()).isEqualTo(Role.ROLE_REJECT);
+        assertThat(result.recordDegree()).isEqualTo("C그룹");
+        assertThat(result.changed()).isTrue();
+        assertThat(user.getRole()).isEqualTo(Role.ROLE_REJECT);
+        assertThat(user.getRecordDegree()).isEqualTo("C그룹");
+        verify(userRepository).save(user);
+        verifyNoInteractions(coolSmsService);
+    }
+
+    @Test
+    @DisplayName("이미 같은 권한과 러닝그룹이면 중복 저장하지 않는다")
+    void processUserApprovalSkipsSameValues() {
+        User user = createUser(Role.ROLE_USER, UserType.GUIDE, "C그룹");
+        when(userRepository.findUserByUserId("user-123")).thenReturn(Optional.of(user));
+
+        UserApprovalResult result = userApprovalService.processUserApproval(
+                "user-123",
+                Role.ROLE_USER,
+                "C그룹",
+                "admin@example.com"
+        );
+
+        assertThat(result.changed()).isFalse();
+        assertThat(result.role()).isEqualTo(Role.ROLE_USER);
+        verifyNoInteractions(coolSmsService);
+    }
+
+    @Test
+    @DisplayName("이미 승인된 회원의 권한이나 러닝그룹을 바꿔도 승인 문자는 발송하지 않는다")
+    void processUserApprovalDoesNotSendSmsWhenPreviousRoleWasNotWait() {
+        User user = createUser(Role.ROLE_USER, UserType.GUIDE, "A");
+        when(userRepository.findUserByUserId("user-123")).thenReturn(Optional.of(user));
+
+        UserApprovalResult result = userApprovalService.processUserApproval(
+                "user-123",
+                Role.ROLE_COACH,
+                "C그룹",
+                "admin@example.com"
+        );
+
+        assertThat(result.role()).isEqualTo(Role.ROLE_COACH);
+        assertThat(result.recordDegree()).isEqualTo("C그룹");
+        assertThat(result.changed()).isTrue();
+        verify(userRepository).save(user);
+        verifyNoInteractions(coolSmsService);
+    }
+
+    private User createUser(Role role, UserType type, String recordDegree) {
+        return User.builder()
+                .userId("user-123")
+                .privateId("private-123")
+                .role(role)
+                .type(type)
+                .name("홍길동")
+                .phoneNumber("01012345678")
+                .recordDegree(recordDegree)
+                .build();
+    }
+}

--- a/run/src/test/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookControllerTest.java
+++ b/run/src/test/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookControllerTest.java
@@ -76,8 +76,8 @@ class AppsmithUserApprovalWebhookControllerTest {
     }
 
     @Test
-    @DisplayName("body secret fallback으로 ROLE_REJECT 요청을 처리한다")
-    void rejectUserWithBodySecretFallback() throws Exception {
+    @DisplayName("헤더 secret으로 ROLE_REJECT 요청을 처리한다")
+    void rejectUserWithHeaderSecret() throws Exception {
         when(userApprovalService.processUserApproval(
                 "user-123",
                 Role.ROLE_REJECT,
@@ -91,10 +91,10 @@ class AppsmithUserApprovalWebhookControllerTest {
         ));
 
         mockMvc.perform(post("/webhook/appsmith/user-approval")
+                        .header("X-Appsmith-Webhook-Secret", "test-secret")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "secret": "test-secret",
                                   "userId": "user-123",
                                   "role": "거절",
                                   "runningGroup": "C그룹",
@@ -114,7 +114,6 @@ class AppsmithUserApprovalWebhookControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "secret": "wrong-secret",
                                   "userId": "user-123",
                                   "role": "ROLE_USER",
                                   "recordDegree": "C그룹"

--- a/run/src/test/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookControllerTest.java
+++ b/run/src/test/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookControllerTest.java
@@ -1,0 +1,162 @@
+package com.guide.run.global.webhook.appsmith.controller;
+
+import com.guide.run.admin.dto.response.UserApprovalResult;
+import com.guide.run.admin.service.UserApprovalService;
+import com.guide.run.user.entity.type.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class AppsmithUserApprovalWebhookControllerTest {
+
+    @Mock
+    private UserApprovalService userApprovalService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        AppsmithUserApprovalWebhookController controller =
+                new AppsmithUserApprovalWebhookController(userApprovalService, "test-secret");
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    @DisplayName("헤더 secret이 맞으면 회원 권한과 러닝그룹 변경 요청을 처리한다")
+    void approveUserWithHeaderSecret() throws Exception {
+        when(userApprovalService.processUserApproval(
+                "user-123",
+                Role.ROLE_USER,
+                "C그룹",
+                "admin@example.com"
+        )).thenReturn(new UserApprovalResult(
+                "user-123",
+                Role.ROLE_USER,
+                "C그룹",
+                true
+        ));
+
+        mockMvc.perform(post("/webhook/appsmith/user-approval")
+                        .header("X-Appsmith-Webhook-Secret", "test-secret")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": "user-123",
+                                  "role": "ROLE_USER",
+                                  "recordDegree": "C그룹",
+                                  "requestedBy": "admin@example.com"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value("user-123"))
+                .andExpect(jsonPath("$.role").value("ROLE_USER"))
+                .andExpect(jsonPath("$.recordDegree").value("C그룹"))
+                .andExpect(jsonPath("$.changed").value(true));
+
+        verify(userApprovalService).processUserApproval(
+                "user-123",
+                Role.ROLE_USER,
+                "C그룹",
+                "admin@example.com"
+        );
+    }
+
+    @Test
+    @DisplayName("body secret fallback으로 ROLE_REJECT 요청을 처리한다")
+    void rejectUserWithBodySecretFallback() throws Exception {
+        when(userApprovalService.processUserApproval(
+                "user-123",
+                Role.ROLE_REJECT,
+                "C그룹",
+                "admin@example.com"
+        )).thenReturn(new UserApprovalResult(
+                "user-123",
+                Role.ROLE_REJECT,
+                "C그룹",
+                true
+        ));
+
+        mockMvc.perform(post("/webhook/appsmith/user-approval")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "secret": "test-secret",
+                                  "userId": "user-123",
+                                  "role": "거절",
+                                  "runningGroup": "C그룹",
+                                  "requestedBy": "admin@example.com"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("ROLE_REJECT"))
+                .andExpect(jsonPath("$.recordDegree").value("C그룹"))
+                .andExpect(jsonPath("$.changed").value(true));
+    }
+
+    @Test
+    @DisplayName("secret이 없거나 틀리면 403을 반환한다")
+    void rejectInvalidSecret() throws Exception {
+        mockMvc.perform(post("/webhook/appsmith/user-approval")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "secret": "wrong-secret",
+                                  "userId": "user-123",
+                                  "role": "ROLE_USER",
+                                  "recordDegree": "C그룹"
+                                }
+                                """))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(userApprovalService);
+    }
+
+    @Test
+    @DisplayName("잘못된 role이면 400을 반환한다")
+    void rejectInvalidRole() throws Exception {
+        mockMvc.perform(post("/webhook/appsmith/user-approval")
+                        .header("X-Appsmith-Webhook-Secret", "test-secret")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": "user-123",
+                                  "role": "HOLD",
+                                  "recordDegree": "C그룹"
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(userApprovalService);
+    }
+
+    @Test
+    @DisplayName("러닝그룹이 없으면 400을 반환한다")
+    void rejectApproveRequestWithoutRecordDegree() throws Exception {
+        mockMvc.perform(post("/webhook/appsmith/user-approval")
+                        .header("X-Appsmith-Webhook-Secret", "test-secret")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": "user-123",
+                                  "role": "ROLE_USER"
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(userApprovalService);
+    }
+}


### PR DESCRIPTION
## 변경 배경
Admin 제거 및 AppSmith 전환을 위해 JWT 없이 호출 가능한 회원 권한/러닝그룹 저장용 웹훅 API를 추가했습니다.

## 주요 변경 사항
- `POST /webhook/appsmith/user-approval` 추가
- `X-Appsmith-Webhook-Secret` 기반 secret 검증 추가
- AppSmith 요청의 `role`, `recordDegree`/`runningGroup` 값을 회원 정보에 저장
- 기존 `ROLE_WAIT` 회원이 `ROLE_REJECT`/`ROLE_WAIT`가 아닌 권한으로 변경될 때만 승인 알림톡 발송
- 기존 Admin 회원 승인 API가 공통 `UserApprovalService`를 재사용하도록 변경
- 환경별 `spring.appsmith.webhook-secret` 설정 추가

## 검증
- `APPSMITH_WEBHOOK_SECRET=test-secret ./gradlew test --tests "*UserApproval*" --tests "*AdminUser*" --tests "*Appsmith*"` 통과
- `git diff --check` 통과

## 운영 참고
- 운영/개발 환경에 `APPSMITH_WEBHOOK_SECRET` 환경변수 설정 필요
- AppSmith에서는 같은 값을 `X-Appsmith-Webhook-Secret` 헤더로 전달해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Appsmith 웹훅(/webhook/appsmith/user-approval)으로 외부 사용자 승인 요청을 받아 처리하도록 추가
  * 승인 처리 로직 통합 및 승인 결과(역할, 기록 등급, 변경 여부) 반환

* **버그 수정**
  * 웹훅 시크릿 검증 및 입력 검증 강화(권한·유효성 오류에 대한 적절한 HTTP 응답)

* **테스트**
  * 승인 서비스 및 웹훅 컨트롤러에 대한 포괄적 단위/웹 계층 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->