### PR TITLE
fix: 복합키 Repository ID 타입 정정

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/CommentLikeId.java
+++ b/run/src/main/java/com/guide/run/event/entity/CommentLikeId.java
@@ -1,6 +1,7 @@
 package com.guide.run.event.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.io.Serializable;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 public class CommentLikeId implements Serializable {
     private Long commentId;
     private String privateId;

--- a/run/src/main/java/com/guide/run/event/entity/EventLikeId.java
+++ b/run/src/main/java/com/guide/run/event/entity/EventLikeId.java
@@ -1,6 +1,7 @@
 package com.guide.run.event.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.io.Serializable;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 public class EventLikeId implements Serializable {
     private Long eventId;
     private String privateId;

--- a/run/src/main/java/com/guide/run/event/entity/repository/CommentLikeRepository.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/CommentLikeRepository.java
@@ -1,12 +1,13 @@
 package com.guide.run.event.entity.repository;
 
 import com.guide.run.event.entity.CommentLike;
+import com.guide.run.event.entity.CommentLikeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface CommentLikeRepository extends JpaRepository<CommentLike,Long> {
+public interface CommentLikeRepository extends JpaRepository<CommentLike, CommentLikeId> {
     List<CommentLike> findAllByCommentId(Long commentId);
     Optional<CommentLike> findByCommentIdAndPrivateId(Long commentId, String privateId);
     Long countByCommentId(Long commentId);

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventLikeRepository.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventLikeRepository.java
@@ -1,11 +1,12 @@
 package com.guide.run.event.entity.repository;
 
 import com.guide.run.event.entity.EventLike;
+import com.guide.run.event.entity.EventLikeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface EventLikeRepository extends JpaRepository<EventLike,Long> {
+public interface EventLikeRepository extends JpaRepository<EventLike, EventLikeId> {
     Optional<EventLike> findByEventIdAndPrivateId(Long eventId, String privateId);
     Long countByEventId(Long eventId);
     void deleteAllByPrivateId(String privateId);

--- a/run/src/main/java/com/guide/run/partner/entity/partner/PartnerLikeId.java
+++ b/run/src/main/java/com/guide/run/partner/entity/partner/PartnerLikeId.java
@@ -1,6 +1,7 @@
 package com.guide.run.partner.entity.partner;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.io.Serializable;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class PartnerLikeId implements Serializable {
     private String recId; //받은 사람 id
     private String sendId; //보낸 사람 id

--- a/run/src/main/java/com/guide/run/partner/entity/partner/repository/PartnerLikeRepository.java
+++ b/run/src/main/java/com/guide/run/partner/entity/partner/repository/PartnerLikeRepository.java
@@ -1,11 +1,12 @@
 package com.guide.run.partner.entity.partner.repository;
 
 import com.guide.run.partner.entity.partner.PartnerLike;
+import com.guide.run.partner.entity.partner.PartnerLikeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface PartnerLikeRepository extends JpaRepository<PartnerLike, String>, PartnerLikeRepositoryCustom {
+public interface PartnerLikeRepository extends JpaRepository<PartnerLike, PartnerLikeId>, PartnerLikeRepositoryCustom {
     Optional<PartnerLike> findByRecIdAndSendId(String partnerId, String privateId);
     void deleteAllByRecId(String privateId);
     void deleteAllBySendId(String privateId);


### PR DESCRIPTION
## 변경 배경
Eclipse/STS Spring Boot validation에서 @IdClass 복합키 엔티티의 Repository ID 타입이 실제 도메인 ID 타입과 다르다는 DOMAIN_ID_FOR_REPOSITORY 오류가 발생했습니다.

## 주요 변경 사항
- EventLikeRepository의 ID 타입을 EventLikeId로 변경
- CommentLikeRepository의 ID 타입을 CommentLikeId로 변경
- PartnerLikeRepository의 ID 타입을 PartnerLikeId로 변경
- 복합키 ID 클래스에 @EqualsAndHashCode 추가

## 영향 범위
- 기존 서비스에서 사용하는 파생 쿼리, save, delete(entity) 호출 시그니처는 변경되지 않습니다.
- 현재 코드 기준 findById, deleteById, existsById, getReferenceById 등 기본 ID 메서드 호출은 없어 컴파일 영향은 없습니다.
- API response DTO나 서비스 로직 변경은 없습니다.

## 검증
- ./gradlew compileJava 성공
- ./gradlew compileTestJava 성공
- git diff --check 성공

## 참고
- ./gradlew test는 현재 테스트 환경에서 ${TEST_RDS}가 JDBC URL로 치환되지 않아 실패합니다. 실패 원인은 Driver com.mysql.cj.jdbc.Driver claims to not accept jdbcUrl, ${TEST_RDS}이며, 이번 Repository ID 타입 변경과는 별개입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 좋아요 기능의 내부 식별자 체계를 개선했습니다. 댓글, 이벤트, 파트너 좋아요 기능의 동일성 비교 및 해싱 로직이 더욱 안정적으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->