### PR TITLE
[codex] create develop sync PR after release

### DIFF
--- a/.github/scripts/wait-codedeploy.sh
+++ b/.github/scripts/wait-codedeploy.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+deployment_id="${1:?deployment id is required}"
+poll_interval="${CODEDEPLOY_POLL_INTERVAL_SECONDS:-15}"
+max_attempts="${CODEDEPLOY_MAX_ATTEMPTS:-120}"
+
+write_summary() {
+  local status="$1"
+  local details="${2:-}"
+
+  if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    return 0
+  fi
+
+  {
+    echo "### CodeDeploy deployment"
+    echo "- Deployment ID: \`$deployment_id\`"
+    echo "- Status: \`$status\`"
+
+    if [[ -n "$details" ]]; then
+      echo
+      echo '```json'
+      echo "$details"
+      echo '```'
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+}
+
+deployment_details() {
+  aws deploy get-deployment \
+    --deployment-id "$deployment_id" \
+    --query 'deploymentInfo.{status:status,errorInformation:errorInformation,deploymentOverview:deploymentOverview}' \
+    --output json
+}
+
+echo "Waiting for CodeDeploy deployment $deployment_id..."
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  status="$(aws deploy get-deployment \
+    --deployment-id "$deployment_id" \
+    --query 'deploymentInfo.status' \
+    --output text)"
+
+  echo "[$attempt/$max_attempts] CodeDeploy status: $status"
+
+  case "$status" in
+    Succeeded)
+      write_summary "$status"
+      echo "CodeDeploy deployment $deployment_id succeeded."
+      exit 0
+      ;;
+    Failed|Stopped)
+      details="$(deployment_details)"
+      echo "CodeDeploy deployment $deployment_id ended with status $status."
+      echo "$details"
+      write_summary "$status" "$details"
+      exit 1
+      ;;
+  esac
+
+  if (( attempt < max_attempts )); then
+    sleep "$poll_interval"
+  fi
+done
+
+details="$(deployment_details || true)"
+echo "Timed out waiting for CodeDeploy deployment $deployment_id after $max_attempts checks."
+echo "$details"
+write_summary "Timed out" "$details"
+exit 1

--- a/.github/scripts/wait-codedeploy.sh
+++ b/.github/scripts/wait-codedeploy.sh
@@ -34,13 +34,32 @@ deployment_details() {
     --output json
 }
 
+get_status() {
+  local retry status
+
+  for retry in 1 2 3; do
+    if status="$(aws deploy get-deployment \
+      --deployment-id "$deployment_id" \
+      --query 'deploymentInfo.status' \
+      --output text)"; then
+      echo "$status"
+      return 0
+    fi
+
+    echo "Failed to fetch CodeDeploy status (retry $retry/3)." >&2
+
+    if [[ "$retry" != "3" ]]; then
+      sleep 3
+    fi
+  done
+
+  return 1
+}
+
 echo "Waiting for CodeDeploy deployment $deployment_id..."
 
 for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-  status="$(aws deploy get-deployment \
-    --deployment-id "$deployment_id" \
-    --query 'deploymentInfo.status' \
-    --output text)"
+  status="$(get_status)"
 
   echo "[$attempt/$max_attempts] CodeDeploy status: $status"
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -54,11 +54,23 @@ jobs:
           aws s3 cp dev-${{ github.sha }}.zip \
             s3://${{ env.S3_BUCKET }}/dev-${{ github.sha }}.zip
 
-      - name: Deploy
+      - name: Create CodeDeploy deployment
+        id: codedeploy
         run: |
-          aws deploy create-deployment \
+          deployment_id=$(aws deploy create-deployment \
             --application-name ${{ env.CODEDEPLOY_APP }} \
             --deployment-group-name ${{ env.DEPLOY_GROUP }} \
             --s3-location bucket=${{ env.S3_BUCKET }},key=dev-${{ github.sha }}.zip,bundleType=zip \
             --deployment-config-name CodeDeployDefault.AllAtOnce \
-            --description "Dev deploy ${{ github.sha }}"
+            --description "Dev deploy ${{ github.sha }}" \
+            --query deploymentId \
+            --output text)
+
+          echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
+          echo "Created CodeDeploy deployment: $deployment_id"
+
+      - name: Wait for CodeDeploy deployment
+        env:
+          CODEDEPLOY_MAX_ATTEMPTS: 120
+          CODEDEPLOY_POLL_INTERVAL_SECONDS: 15
+        run: bash .github/scripts/wait-codedeploy.sh "${{ steps.codedeploy.outputs.deployment_id }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,14 +54,26 @@ jobs:
           aws s3 cp ${{ github.event.release.tag_name }}.zip \
             s3://${{ env.S3_BUCKET }}/${{ github.event.release.tag_name }}.zip
 
-      - name: Deploy
+      - name: Create CodeDeploy deployment
+        id: codedeploy
         run: |
-          aws deploy create-deployment \
+          deployment_id=$(aws deploy create-deployment \
             --application-name ${{ env.CODEDEPLOY_APP }} \
             --deployment-group-name ${{ env.DEPLOY_GROUP }} \
             --s3-location bucket=${{ env.S3_BUCKET }},key=${{ github.event.release.tag_name }}.zip,bundleType=zip \
             --deployment-config-name CodeDeployDefault.OneAtATime \
-            --description "Release ${{ github.event.release.tag_name }}"
+            --description "Release ${{ github.event.release.tag_name }}" \
+            --query deploymentId \
+            --output text)
+
+          echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
+          echo "Created CodeDeploy deployment: $deployment_id"
+
+      - name: Wait for CodeDeploy deployment
+        env:
+          CODEDEPLOY_MAX_ATTEMPTS: 120
+          CODEDEPLOY_POLL_INTERVAL_SECONDS: 15
+        run: bash .github/scripts/wait-codedeploy.sh "${{ steps.codedeploy.outputs.deployment_id }}"
 
   sync-develop-pr:
     needs: build-and-deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,3 +62,51 @@ jobs:
             --s3-location bucket=${{ env.S3_BUCKET }},key=${{ github.event.release.tag_name }}.zip,bundleType=zip \
             --deployment-config-name CodeDeployDefault.OneAtATime \
             --description "Release ${{ github.event.release.tag_name }}"
+
+  sync-develop-pr:
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    if: ${{ github.event.release.target_commitish == 'main' }}
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whether main has file changes not in develop
+        id: diff
+        run: |
+          git fetch origin main develop
+
+          if git diff --quiet origin/develop...origin/main; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create sync PR
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          open_pr_count=$(gh pr list \
+            --base develop \
+            --head main \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          if [ "$open_pr_count" -gt 0 ]; then
+            echo "Sync PR from main to develop already exists."
+            exit 0
+          fi
+
+          gh pr create \
+            --base develop \
+            --head main \
+            --title "chore: sync main into develop after release" \
+            --body "Production release ${{ github.event.release.tag_name }} was published. This PR syncs main back into develop."


### PR DESCRIPTION
## Summary
- Add a post-release workflow job that runs after production deployment succeeds.
- Detect whether main has file changes not present in develop.
- Create a main to develop sync PR only when needed, while skipping duplicate open sync PRs.

## Validation
- git diff --check
- Ruby YAML parse for .github/workflows/deploy.yml

## Notes
- Repository settings must allow GitHub Actions to create pull requests for this workflow to open sync PRs with GITHUB_TOKEN.
- The workflow does not push directly to develop; it only creates a PR for manual merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 프로덕션 릴리스 후 메인 브랜치의 변경사항을 자동으로 개발 브랜치와 동기화하는 배포 후 프로세스를 추가했습니다. 중복 PR 생성을 방지하는 검증 로직이 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->