### PR TITLE
ci: CodeDeploy 완료 상태 확인 후 후속 작업 실행

### DIFF
--- a/.github/scripts/wait-codedeploy.sh
+++ b/.github/scripts/wait-codedeploy.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+deployment_id="${1:?deployment id is required}"
+poll_interval="${CODEDEPLOY_POLL_INTERVAL_SECONDS:-15}"
+max_attempts="${CODEDEPLOY_MAX_ATTEMPTS:-120}"
+
+write_summary() {
+  local status="$1"
+  local details="${2:-}"
+
+  if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    return 0
+  fi
+
+  {
+    echo "### CodeDeploy deployment"
+    echo "- Deployment ID: \`$deployment_id\`"
+    echo "- Status: \`$status\`"
+
+    if [[ -n "$details" ]]; then
+      echo
+      echo '```json'
+      echo "$details"
+      echo '```'
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+}
+
+deployment_details() {
+  aws deploy get-deployment \
+    --deployment-id "$deployment_id" \
+    --query 'deploymentInfo.{status:status,errorInformation:errorInformation,deploymentOverview:deploymentOverview}' \
+    --output json
+}
+
+echo "Waiting for CodeDeploy deployment $deployment_id..."
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  status="$(aws deploy get-deployment \
+    --deployment-id "$deployment_id" \
+    --query 'deploymentInfo.status' \
+    --output text)"
+
+  echo "[$attempt/$max_attempts] CodeDeploy status: $status"
+
+  case "$status" in
+    Succeeded)
+      write_summary "$status"
+      echo "CodeDeploy deployment $deployment_id succeeded."
+      exit 0
+      ;;
+    Failed|Stopped)
+      details="$(deployment_details)"
+      echo "CodeDeploy deployment $deployment_id ended with status $status."
+      echo "$details"
+      write_summary "$status" "$details"
+      exit 1
+      ;;
+  esac
+
+  if (( attempt < max_attempts )); then
+    sleep "$poll_interval"
+  fi
+done
+
+details="$(deployment_details || true)"
+echo "Timed out waiting for CodeDeploy deployment $deployment_id after $max_attempts checks."
+echo "$details"
+write_summary "Timed out" "$details"
+exit 1

--- a/.github/scripts/wait-codedeploy.sh
+++ b/.github/scripts/wait-codedeploy.sh
@@ -34,13 +34,32 @@ deployment_details() {
     --output json
 }
 
+get_status() {
+  local retry status
+
+  for retry in 1 2 3; do
+    if status="$(aws deploy get-deployment \
+      --deployment-id "$deployment_id" \
+      --query 'deploymentInfo.status' \
+      --output text)"; then
+      echo "$status"
+      return 0
+    fi
+
+    echo "Failed to fetch CodeDeploy status (retry $retry/3)." >&2
+
+    if [[ "$retry" != "3" ]]; then
+      sleep 3
+    fi
+  done
+
+  return 1
+}
+
 echo "Waiting for CodeDeploy deployment $deployment_id..."
 
 for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-  status="$(aws deploy get-deployment \
-    --deployment-id "$deployment_id" \
-    --query 'deploymentInfo.status' \
-    --output text)"
+  status="$(get_status)"
 
   echo "[$attempt/$max_attempts] CodeDeploy status: $status"
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -54,11 +54,23 @@ jobs:
           aws s3 cp dev-${{ github.sha }}.zip \
             s3://${{ env.S3_BUCKET }}/dev-${{ github.sha }}.zip
 
-      - name: Deploy
+      - name: Create CodeDeploy deployment
+        id: codedeploy
         run: |
-          aws deploy create-deployment \
+          deployment_id=$(aws deploy create-deployment \
             --application-name ${{ env.CODEDEPLOY_APP }} \
             --deployment-group-name ${{ env.DEPLOY_GROUP }} \
             --s3-location bucket=${{ env.S3_BUCKET }},key=dev-${{ github.sha }}.zip,bundleType=zip \
             --deployment-config-name CodeDeployDefault.AllAtOnce \
-            --description "Dev deploy ${{ github.sha }}"
+            --description "Dev deploy ${{ github.sha }}" \
+            --query deploymentId \
+            --output text)
+
+          echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
+          echo "Created CodeDeploy deployment: $deployment_id"
+
+      - name: Wait for CodeDeploy deployment
+        env:
+          CODEDEPLOY_MAX_ATTEMPTS: 120
+          CODEDEPLOY_POLL_INTERVAL_SECONDS: 15
+        run: bash .github/scripts/wait-codedeploy.sh "${{ steps.codedeploy.outputs.deployment_id }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,14 +54,26 @@ jobs:
           aws s3 cp ${{ github.event.release.tag_name }}.zip \
             s3://${{ env.S3_BUCKET }}/${{ github.event.release.tag_name }}.zip
 
-      - name: Deploy
+      - name: Create CodeDeploy deployment
+        id: codedeploy
         run: |
-          aws deploy create-deployment \
+          deployment_id=$(aws deploy create-deployment \
             --application-name ${{ env.CODEDEPLOY_APP }} \
             --deployment-group-name ${{ env.DEPLOY_GROUP }} \
             --s3-location bucket=${{ env.S3_BUCKET }},key=${{ github.event.release.tag_name }}.zip,bundleType=zip \
             --deployment-config-name CodeDeployDefault.OneAtATime \
-            --description "Release ${{ github.event.release.tag_name }}"
+            --description "Release ${{ github.event.release.tag_name }}" \
+            --query deploymentId \
+            --output text)
+
+          echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
+          echo "Created CodeDeploy deployment: $deployment_id"
+
+      - name: Wait for CodeDeploy deployment
+        env:
+          CODEDEPLOY_MAX_ATTEMPTS: 120
+          CODEDEPLOY_POLL_INTERVAL_SECONDS: 15
+        run: bash .github/scripts/wait-codedeploy.sh "${{ steps.codedeploy.outputs.deployment_id }}"
 
   sync-develop-pr:
     needs: build-and-deploy


### PR DESCRIPTION
## 변경 배경

기존 릴리스 배포 workflow는 `aws deploy create-deployment` 호출이 성공하면 GitHub Actions가 성공 처리되었습니다. 하지만 이 명령은 CodeDeploy 배포를 생성하는 단계까지만 보장하므로, 실제 EC2 배포 성공 여부는 AWS CodeDeploy 콘솔에서 별도로 확인해야 했습니다.

또한 `main` 내용을 `develop`에 반영하는 동기화 PR은 운영 배포가 실제로 성공한 뒤에만 생성되는 편이 더 안전합니다.

## 주요 변경 사항

- CodeDeploy 배포 생성 시 반환되는 `deploymentId`를 GitHub Actions output으로 저장
- `deploymentId`를 기준으로 CodeDeploy 상태를 polling하는 공용 스크립트 추가
- 배포 상태가 `Succeeded`일 때만 workflow가 성공하도록 변경
- 배포 상태가 `Failed`, `Stopped`, timeout인 경우 workflow를 실패 처리하고 상세 정보를 로그와 step summary에 출력
- prod/dev 배포 workflow 모두 동일한 방식으로 CodeDeploy 완료 상태를 확인하도록 적용

## 기대 효과

- GitHub Actions 화면에서 CodeDeploy 실제 성공/실패 여부를 확인할 수 있습니다.
- 운영 배포 실패 시 `sync-develop-pr` job이 실행되지 않습니다.
- `main -> develop` 동기화 PR은 운영 CodeDeploy 배포가 성공한 경우에만 생성됩니다.

## 검증

- `bash -n .github/scripts/wait-codedeploy.sh`
- `.github/workflows/deploy.yml`, `.github/workflows/deploy-dev.yml` YAML 파싱 확인
- `git diff --check`

## 참고

- 현재 GitHub Actions에서 사용하는 AWS 권한에 `AWSCodeDeployFullAccess`, `AmazonS3FullAccess`가 설정되어 있어 `codedeploy:GetDeployment` 조회와 S3 업로드에 필요한 권한은 충족됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 배포 프로세스 개선: 자동 배포 완료 모니터링 기능 추가로 배포 상태를 실시간 추적 가능하게 개선. 배포 성공, 실패, 타임아웃 상황에 대한 상세한 피드백 및 로그 제공으로 배포 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->