### PR TITLE
fix: AppSmith 웹훅 CORS origin 제한

### DIFF
--- a/run/src/main/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookController.java
+++ b/run/src/main/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookController.java
@@ -22,7 +22,7 @@ import java.util.Locale;
 
 @Slf4j
 @RestController
-@CrossOrigin(origins = "*")
+@CrossOrigin(origins = "https://grp.appsmith.com")
 public class AppsmithUserApprovalWebhookController {
 
     private static final String SECRET_HEADER = "X-Appsmith-Webhook-Secret";

--- a/run/src/test/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookControllerTest.java
+++ b/run/src/test/java/com/guide/run/global/webhook/appsmith/controller/AppsmithUserApprovalWebhookControllerTest.java
@@ -12,7 +12,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.CrossOrigin;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -33,6 +35,15 @@ class AppsmithUserApprovalWebhookControllerTest {
         AppsmithUserApprovalWebhookController controller =
                 new AppsmithUserApprovalWebhookController(userApprovalService, "test-secret");
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    @DisplayName("AppSmith origin만 CORS 허용 origin으로 설정한다")
+    void allowOnlyAppsmithOrigin() {
+        CrossOrigin crossOrigin = AppsmithUserApprovalWebhookController.class.getAnnotation(CrossOrigin.class);
+
+        assertThat(crossOrigin).isNotNull();
+        assertThat(crossOrigin.origins()).containsExactly("https://grp.appsmith.com");
     }
 
     @Test


### PR DESCRIPTION
## 변경 배경
AppSmith client fetch 호출 origin이 `https://grp.appsmith.com`으로 확인되어, 회원 승인 웹훅의 CORS 허용 범위를 wildcard에서 해당 origin으로 좁혔습니다.

## 주요 변경 사항
- `POST /webhook/appsmith/user-approval` 컨트롤러의 `@CrossOrigin`을 `*`에서 `https://grp.appsmith.com`으로 제한
- 컨트롤러 테스트에서 AppSmith origin만 허용되도록 설정 검증 추가

## 검증
- `./gradlew test --tests "*AppsmithUserApprovalWebhookControllerTest"`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **보안**
  * API 요청에 대한 Cross-Origin 접근 정책이 강화되었습니다.

* **테스트**
  * 접근 제한 검증 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->