### PR TITLE
Fix: 주최 이벤트 러닝거리 스킵 처리

### DIFF
--- a/run/src/main/java/com/guide/run/event/controller/EventController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventController.java
@@ -64,6 +64,16 @@ public class EventController {
         ));
     }
 
+    @Operation(summary = "이벤트 러닝 거리 입력 스킵", description = "이벤트 주최자가 종료 이벤트의 러닝 거리 입력을 스킵합니다. 스킵 값은 0km로 저장됩니다.")
+    @PatchMapping("/{eventId}/running-distance/skip")
+    public ResponseEntity<EventRunningDistancePatchResponse> skipRunningDistance(
+            @PathVariable Long eventId,
+            HttpServletRequest request
+    ) {
+        String privateId = jwtProvider.extractUserId(request);
+        return ResponseEntity.ok(eventService.skipRunningDistance(eventId, privateId));
+    }
+
     @Operation(summary = "이벤트 수정", description = "이벤트 수정 화면에서 기존 이벤트를 수정합니다. 수정 후 스케줄러 정보도 함께 갱신됩니다.")
     @PatchMapping("/{eventId}")
     public ResponseEntity<EventUpdatedResponse> eventUpdate(@PathVariable Long eventId,@RequestBody EventCreateRequest request, HttpServletRequest httpServletRequest){

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepository.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepository.java
@@ -1,16 +1,10 @@
 package com.guide.run.event.entity.repository;
 
 import com.guide.run.event.entity.EventForm;
-import com.guide.run.event.entity.Event;
 import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.user.entity.type.UserType;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface EventFormRepository extends JpaRepository <EventForm,Long> ,EventFormRepositoryAdmin,EventFormRepositoryCustom {
@@ -26,35 +20,4 @@ public interface EventFormRepository extends JpaRepository <EventForm,Long> ,Eve
     long countByEventIdAndTypeAndStatus(Long eventId, UserType type, EventFormStatus status);
 
     long countByPrivateId(String privateId);
-
-    @Query("""
-            select event
-            from EventForm form, Event event
-            where form.eventId = event.id
-              and form.privateId = :privateId
-              and form.status = :status
-              and event.endTime < :now
-              and (form.runningDistanceKm is null or form.runningDistanceKm = :zero)
-            order by event.endTime desc, event.id desc
-            """)
-    List<Event> findLatestMissingRunningDistanceEvents(
-            @Param("privateId") String privateId,
-            @Param("status") EventFormStatus status,
-            @Param("now") LocalDateTime now,
-            @Param("zero") BigDecimal zero,
-            Pageable pageable
-    );
-
-    @Query("""
-            select form
-            from EventForm form
-            where form.eventId = :eventId
-              and form.status = :status
-              and (form.runningDistanceKm is null or form.runningDistanceKm = :zero)
-            """)
-    List<EventForm> findAllMissingRunningDistanceForms(
-            @Param("eventId") Long eventId,
-            @Param("status") EventFormStatus status,
-            @Param("zero") BigDecimal zero
-    );
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepository.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepository.java
@@ -38,4 +38,10 @@ public interface EventRepository extends JpaRepository<Event,Long>, EventReposit
             LocalDateTime now
     );
 
+    List<Event> findAllByOrganizerAndEndTimeBeforeAndExpectedRunningDistanceKmIsNullOrderByEndTimeDescIdDesc(
+            String organizer,
+            LocalDateTime now,
+            Pageable pageable
+    );
+
 }

--- a/run/src/main/java/com/guide/run/event/service/EventService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventService.java
@@ -197,10 +197,6 @@ public class EventService {
 
         Event event = eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
         if (event.getOrganizer().equals(privateId)) {
-            boolean expectedRunningDistanceChanged = isExpectedRunningDistanceChanged(
-                    event.getExpectedRunningDistanceKm(),
-                    request.getExpectedRunningDistanceKm()
-            );
             if (request.getAdditionalQuestions() != null) {
                 long appliedCount = eventFormRepository.countByEventIdAndStatus(eventId, EventFormStatus.APPLIED);
                 if (appliedCount > 0) {
@@ -232,9 +228,6 @@ public class EventService {
 
             if (request.getAdditionalQuestions() != null) {
                 eventAdditionalInfoService.replaceQuestions(eventId, request.getAdditionalQuestions());
-            }
-            if (expectedRunningDistanceChanged && request.getExpectedRunningDistanceKm() != null) {
-                syncMissingFormRunningDistances(eventId, request.getExpectedRunningDistanceKm());
             }
 
             return EventUpdatedResponse.builder()
@@ -427,12 +420,10 @@ public class EventService {
     }
 
     public MissingRunningDistanceGetResponse getMissingRunningDistance(String privateId) {
-        List<MissingRunningDistanceGetResponse.Item> items = eventFormRepository
-                .findLatestMissingRunningDistanceEvents(
+        List<MissingRunningDistanceGetResponse.Item> items = eventRepository
+                .findAllByOrganizerAndEndTimeBeforeAndExpectedRunningDistanceKmIsNullOrderByEndTimeDescIdDesc(
                         privateId,
-                        EventFormStatus.APPLIED,
                         LocalDateTime.now(),
-                        BigDecimal.ZERO,
                         PageRequest.of(0, 1)
                 )
                 .stream()
@@ -451,27 +442,33 @@ public class EventService {
     @Transactional
     public EventRunningDistancePatchResponse patchRunningDistance(Long eventId, String privateId, BigDecimal distance) {
         Event event = eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
-        if (event.getEndTime().isAfter(LocalDateTime.now()) || event.getEndTime().isEqual(LocalDateTime.now())) {
-            throw new EventValidationException("종료된 이벤트만 러닝 거리를 등록할 수 있습니다.");
-        }
         if (distance == null || distance.compareTo(BigDecimal.ZERO) <= 0) {
             throw new EventValidationException("러닝 거리는 0보다 커야 합니다.");
         }
-        EventForm form = eventFormRepository.findByEventIdAndPrivateIdAndStatus(
-                eventId,
-                privateId,
-                EventFormStatus.APPLIED
-        );
-        if (form == null) {
-            throw new NotExistEventException("해당 이벤트에 대한 신청 폼이 존재하지 않습니다.");
+        return updateRunningDistance(event, privateId, distance);
+    }
+
+    @Transactional
+    public EventRunningDistancePatchResponse skipRunningDistance(Long eventId, String privateId) {
+        Event event = eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
+        return updateRunningDistance(event, privateId, BigDecimal.ZERO);
+    }
+
+    private EventRunningDistancePatchResponse updateRunningDistance(Event event, String privateId, BigDecimal distance) {
+        if (!event.getOrganizer().equals(privateId)) {
+            throw new NotEventOrganizerException();
+        }
+        if (event.getEndTime().isAfter(LocalDateTime.now()) || event.getEndTime().isEqual(LocalDateTime.now())) {
+            throw new EventValidationException("종료된 이벤트만 러닝 거리를 등록할 수 있습니다.");
         }
 
-        form.updateRunningDistanceKm(distance);
-        eventFormRepository.save(form);
+        event.updateExpectedRunningDistanceKm(distance);
+        eventRepository.save(event);
+        syncAppliedFormRunningDistances(event.getId(), distance);
 
         return EventRunningDistancePatchResponse.builder()
                 .eventId(event.getId())
-                .expectedRunningDistanceKm(form.getRunningDistanceKm())
+                .expectedRunningDistanceKm(event.getExpectedRunningDistanceKm())
                 .build();
     }
 
@@ -528,24 +525,10 @@ public class EventService {
                 + startTime.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN) + ")";
     }
 
-    private boolean isExpectedRunningDistanceChanged(BigDecimal before, BigDecimal after) {
-        if (before == null && after == null) {
-            return false;
-        }
-        if (before == null || after == null) {
-            return true;
-        }
-        return before.compareTo(after) != 0;
-    }
-
-    private void syncMissingFormRunningDistances(Long eventId, BigDecimal expectedRunningDistanceKm) {
-        List<EventForm> forms = eventFormRepository.findAllMissingRunningDistanceForms(
-                eventId,
-                EventFormStatus.APPLIED,
-                BigDecimal.ZERO
-        );
+    private void syncAppliedFormRunningDistances(Long eventId, BigDecimal runningDistanceKm) {
+        List<EventForm> forms = eventFormRepository.findAllByEventIdAndStatus(eventId, EventFormStatus.APPLIED);
         for (EventForm form : forms) {
-            form.updateRunningDistanceKm(expectedRunningDistanceKm);
+            form.updateRunningDistanceKm(runningDistanceKm);
         }
         eventFormRepository.saveAll(forms);
     }

--- a/run/src/test/java/com/guide/run/event/controller/EventFormControllerTest.java
+++ b/run/src/test/java/com/guide/run/event/controller/EventFormControllerTest.java
@@ -22,4 +22,17 @@ class EventFormControllerTest {
 
         assertThat(hasLegacyMapping).isFalse();
     }
+
+    @Test
+    @DisplayName("러닝 거리 스킵 API는 이벤트 컨트롤러에 PATCH로 노출한다")
+    void runningDistanceSkipEndpointIsExposed() {
+        boolean hasSkipMapping = Arrays.stream(EventController.class.getDeclaredMethods())
+                .map(method -> method.getAnnotation(org.springframework.web.bind.annotation.PatchMapping.class))
+                .filter(mapping -> mapping != null)
+                .map(org.springframework.web.bind.annotation.PatchMapping::value)
+                .flatMap(Arrays::stream)
+                .anyMatch("/{eventId}/running-distance/skip"::equals);
+
+        assertThat(hasSkipMapping).isTrue();
+    }
 }

--- a/run/src/test/java/com/guide/run/event/service/EventRenewalServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventRenewalServiceTest.java
@@ -29,7 +29,6 @@ import com.guide.run.global.converter.TimeFormatter;
 import com.guide.run.global.exception.event.authorize.NotEventOrganizerException;
 import com.guide.run.global.exception.event.logic.CannotModifyAdditionalQuestionsException;
 import com.guide.run.global.exception.event.logic.EventValidationException;
-import com.guide.run.global.exception.event.resource.NotExistEventException;
 import com.guide.run.global.exception.user.authorize.NotAuthorizationException;
 import com.guide.run.partner.entity.matching.repository.MatchingRepository;
 import com.guide.run.partner.entity.matching.repository.UnMatchingRepository;
@@ -198,47 +197,6 @@ class EventRenewalServiceTest {
     }
 
     @Test
-    @DisplayName("이벤트 수정은 예상 거리가 변경되면 미입력 신청서만 새 예상 거리로 동기화한다")
-    void eventUpdateSyncsOnlyMissingFormRunningDistancesWhenExpectedDistanceChanges() {
-        User organizer = createUser("organizer-private", "organizer-user", "홍길동", UserType.GUIDE);
-        Event event = createEvent("organizer-private");
-        EventForm nullDistanceForm = EventForm.builder()
-                .id(1L)
-                .eventId(99L)
-                .privateId("vi-private")
-                .status(EventFormStatus.APPLIED)
-                .runningDistanceKm(null)
-                .build();
-        EventForm zeroDistanceForm = EventForm.builder()
-                .id(2L)
-                .eventId(99L)
-                .privateId("guide-private")
-                .status(EventFormStatus.APPLIED)
-                .runningDistanceKm(BigDecimal.ZERO)
-                .build();
-        EventCreateRequest request = createEventRequest(false, new BigDecimal("9.20"), null);
-
-        when(userRepository.findUserByPrivateId("organizer-private")).thenReturn(Optional.of(organizer));
-        when(timeFormatter.getDateTime("2026-06-20", "09:00"))
-                .thenReturn(LocalDateTime.of(2026, 6, 20, 9, 0));
-        when(timeFormatter.getDateTime("2026-06-20", "11:00"))
-                .thenReturn(LocalDateTime.of(2026, 6, 20, 11, 0));
-        when(eventRepository.findById(99L)).thenReturn(Optional.of(event));
-        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(eventFormRepository.findAllMissingRunningDistanceForms(
-                99L,
-                EventFormStatus.APPLIED,
-                BigDecimal.ZERO
-        )).thenReturn(List.of(nullDistanceForm, zeroDistanceForm));
-
-        eventService.eventUpdate(request, "organizer-private", 99L);
-
-        assertThat(nullDistanceForm.getRunningDistanceKm()).isEqualByComparingTo("9.20");
-        assertThat(zeroDistanceForm.getRunningDistanceKm()).isEqualByComparingTo("9.20");
-        verify(eventFormRepository).saveAll(List.of(nullDistanceForm, zeroDistanceForm));
-    }
-
-    @Test
     @DisplayName("이벤트 수정은 신청자가 있으면 추가 질문 변경을 거부한다")
     void eventUpdateRejectsAdditionalQuestionsWhenAppliedFormExists() {
         User organizer = createUser("organizer-private", "organizer-user", "홍길동", UserType.GUIDE);
@@ -278,18 +236,16 @@ class EventRenewalServiceTest {
     }
 
     @Test
-    @DisplayName("러닝 거리 미입력 이벤트 조회는 내가 참여한 종료 이벤트 중 최신 1개를 반환한다")
-    void getMissingRunningDistanceReturnsLatestParticipatedEndedEvent() {
+    @DisplayName("러닝 거리 미입력 이벤트 조회는 내가 주최한 종료 이벤트 중 최신 1개를 반환한다")
+    void getMissingRunningDistanceReturnsLatestOrganizerEndedEvent() {
         Event missingDistanceEvent = createEndedEventWithoutExpectedDistance(10L, "상계천천히달리기");
-        when(eventFormRepository.findLatestMissingRunningDistanceEvents(
-                eq("participant-private"),
-                eq(EventFormStatus.APPLIED),
+        when(eventRepository.findAllByOrganizerAndEndTimeBeforeAndExpectedRunningDistanceKmIsNullOrderByEndTimeDescIdDesc(
+                eq("organizer-private"),
                 any(LocalDateTime.class),
-                eq(BigDecimal.ZERO),
                 any(Pageable.class)
         )).thenReturn(List.of(missingDistanceEvent));
 
-        MissingRunningDistanceGetResponse response = eventService.getMissingRunningDistance("participant-private");
+        MissingRunningDistanceGetResponse response = eventService.getMissingRunningDistance("organizer-private");
 
         assertThat(response.getItems()).hasSize(1);
         MissingRunningDistanceGetResponse.Item item = response.getItems().get(0);
@@ -299,37 +255,42 @@ class EventRenewalServiceTest {
     }
 
     @Test
-    @DisplayName("러닝 거리 등록은 현재 사용자의 신청서 거리만 갱신한다")
-    void patchRunningDistanceUpdatesAppliedFormDistance() {
+    @DisplayName("러닝 거리 등록은 이벤트 예상 거리와 APPLIED 신청서 거리를 함께 갱신한다")
+    void patchRunningDistanceUpdatesEventAndAppliedFormDistances() {
         Event event = createEndedEventWithoutExpectedDistance(1L, "상계천천히달리기");
-        EventForm form = EventForm.builder()
+        EventForm viForm = EventForm.builder()
                 .id(55L)
                 .eventId(1L)
-                .privateId("participant-private")
+                .privateId("vi-private")
                 .status(EventFormStatus.APPLIED)
                 .runningDistanceKm(null)
+                .build();
+        EventForm guideForm = EventForm.builder()
+                .id(56L)
+                .eventId(1L)
+                .privateId("guide-private")
+                .status(EventFormStatus.APPLIED)
+                .runningDistanceKm(new BigDecimal("3.00"))
                 .build();
         BigDecimal distance = new BigDecimal("8.25");
 
         when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
-        when(eventFormRepository.findByEventIdAndPrivateIdAndStatus(
-                1L,
-                "participant-private",
-                EventFormStatus.APPLIED
-        )).thenReturn(form);
+        when(eventFormRepository.findAllByEventIdAndStatus(1L, EventFormStatus.APPLIED))
+                .thenReturn(List.of(viForm, guideForm));
 
         EventRunningDistancePatchResponse response = eventService.patchRunningDistance(
                 1L,
-                "participant-private",
+                "organizer-private",
                 distance
         );
 
-        assertThat(event.getExpectedRunningDistanceKm()).isNull();
-        assertThat(form.getRunningDistanceKm()).isEqualByComparingTo("8.25");
+        assertThat(event.getExpectedRunningDistanceKm()).isEqualByComparingTo("8.25");
+        assertThat(viForm.getRunningDistanceKm()).isEqualByComparingTo("8.25");
+        assertThat(guideForm.getRunningDistanceKm()).isEqualByComparingTo("8.25");
         assertThat(response.getEventId()).isEqualTo(1L);
         assertThat(response.getExpectedRunningDistanceKm()).isEqualByComparingTo("8.25");
-        verify(eventFormRepository).save(form);
-        verify(eventRepository, never()).save(event);
+        verify(eventRepository).save(event);
+        verify(eventFormRepository).saveAll(List.of(viForm, guideForm));
     }
 
     @Test
@@ -365,23 +326,45 @@ class EventRenewalServiceTest {
     }
 
     @Test
-    @DisplayName("러닝 거리 등록은 현재 사용자의 APPLIED 신청서가 없으면 거부한다")
-    void patchRunningDistanceRejectsMissingAppliedForm() {
+    @DisplayName("러닝 거리 등록은 주최자가 아니면 거부한다")
+    void patchRunningDistanceRejectsNonOrganizer() {
         Event event = createEndedEventWithoutExpectedDistance(1L, "상계천천히달리기");
 
         when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
-        when(eventFormRepository.findByEventIdAndPrivateIdAndStatus(
-                1L,
-                "participant-private",
-                EventFormStatus.APPLIED
-        )).thenReturn(null);
 
         assertThatThrownBy(() -> eventService.patchRunningDistance(
                 1L,
-                "participant-private",
+                "other-private",
                 new BigDecimal("8.25")
-        )).isInstanceOf(NotExistEventException.class);
-        verify(eventFormRepository, never()).save(any(EventForm.class));
+        )).isInstanceOf(NotEventOrganizerException.class);
+        verify(eventRepository, never()).save(any(Event.class));
+        verify(eventFormRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("러닝 거리 스킵은 이벤트 예상 거리와 APPLIED 신청서 거리를 0으로 갱신한다")
+    void skipRunningDistanceUpdatesEventAndAppliedFormDistancesToZero() {
+        Event event = createEndedEventWithoutExpectedDistance(1L, "상계천천히달리기");
+        EventForm form = EventForm.builder()
+                .id(55L)
+                .eventId(1L)
+                .privateId("vi-private")
+                .status(EventFormStatus.APPLIED)
+                .runningDistanceKm(null)
+                .build();
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(eventFormRepository.findAllByEventIdAndStatus(1L, EventFormStatus.APPLIED))
+                .thenReturn(List.of(form));
+
+        EventRunningDistancePatchResponse response = eventService.skipRunningDistance(1L, "organizer-private");
+
+        assertThat(event.getExpectedRunningDistanceKm()).isEqualByComparingTo("0");
+        assertThat(form.getRunningDistanceKm()).isEqualByComparingTo("0");
+        assertThat(response.getEventId()).isEqualTo(1L);
+        assertThat(response.getExpectedRunningDistanceKm()).isEqualByComparingTo("0");
+        verify(eventRepository).save(event);
+        verify(eventFormRepository).saveAll(List.of(form));
     }
 
     @Test


### PR DESCRIPTION
## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
- 러닝 거리 미입력 조회를 주최 이벤트 기준 최신 1건으로 정리
- 러닝 거리 등록 시 이벤트 예상 거리와 APPLIED 신청서 거리 동기화
- 러닝 거리 입력 스킵 API 추가

## **변경 내용**
- `PATCH /api/event/{eventId}/running-distance/skip` 추가
- 주최자가 러닝 거리를 등록하면 `event.expected_running_distance_km`와 신청자 `event_form.running_distance_km`가 같은 값으로 저장됨
- 주최자가 러닝 거리 입력을 스킵하면 두 값 모두 `0`으로 저장되어 미입력 목록에서 제외됨

## **관련 이슈**
Resolves: 없음

See also: 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 종료된 이벤트에서 러닝 거리 스킵 기능 추가
  * 러닝 거리 등록 시 해당 이벤트의 모든 참여 정보에 자동 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->