### PR TITLE
fix: 전역 CORS 허용 목록 적용

### DIFF
--- a/run/src/main/java/com/guide/run/event/controller/EventGetController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventGetController.java
@@ -27,9 +27,6 @@ import org.springframework.web.bind.annotation.*;
 import static com.guide.run.event.entity.type.EventRecruitStatus.*;
 import static com.guide.run.event.entity.type.EventType.*;
 
-@CrossOrigin(origins = {"https://guide-run-qa.netlify.app", "https://guiderun.org",
-        "https://guide-run.netlify.app","https://www.guiderun.org", "http://localhost:3000"},
-        maxAge = 3600)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")

--- a/run/src/main/java/com/guide/run/event/controller/EventMatchingController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventMatchingController.java
@@ -12,9 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@CrossOrigin(origins = {"https://guide-run-qa.netlify.app", "https://guiderun.org",
-        "https://guide-run.netlify.app","https://www.guiderun.org", "http://localhost:3000"},
-        maxAge = 3600)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")

--- a/run/src/main/java/com/guide/run/event/controller/EventSearchController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventSearchController.java
@@ -23,9 +23,6 @@ import org.springframework.web.bind.annotation.*;
 import static com.guide.run.event.entity.type.EventRecruitStatus.*;
 import static com.guide.run.event.entity.type.EventType.*;
 
-@CrossOrigin(origins = {"https://guide-run-qa.netlify.app", "https://guiderun.org",
-        "https://guide-run.netlify.app","https://www.guiderun.org", "http://localhost:3000"},
-        maxAge = 3600)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/event")

--- a/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
+++ b/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
@@ -19,14 +19,26 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 
 
 @RequiredArgsConstructor
 @Configuration
 @EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
+    private static final List<String> DEFAULT_ALLOWED_ORIGINS = List.of(
+            "https://dev.guiderun.org",
+            "https://guiderun.org",
+            "https://www.guiderun.org"
+    );
+
     private final JwtProvider jwtProvider;
-     @Value("${cors.origin}")
+
+    @Value("${cors.allowed-origins:${cors.origin:}}")
     private String origin;
 
     @Bean
@@ -43,21 +55,7 @@ public class SecurityConfig {
                     .requestMatchers("/health")
                     .requestMatchers("/webhook/tosspayments")
                     .requestMatchers("/webhook/appsmith/user-approval")
-                    .requestMatchers("/favicon.ico")
-                    .requestMatchers("/member-upload")
-                    .requestMatchers("/event-upload")
-                    .requestMatchers("/attendance-upload")
-                    .requestMatchers("/api/oauth/**")
-                    .requestMatchers("/api/sms/**")
-                    .requestMatchers("/api/accountId")
-                    .requestMatchers("/api/new-password")
-                    .requestMatchers("/api/event/summary")
-                    .requestMatchers("/tmp/**")
-                    .requestMatchers("/api/login")
-                    .requestMatchers("/v3/api-docs/**")
-                    .requestMatchers("/v3/api-docs")
-                    .requestMatchers("/swagger-ui/**")
-                    .requestMatchers("/swagger-ui.html");
+                    .requestMatchers("/favicon.ico");
         };
     }
     @Bean
@@ -81,6 +79,7 @@ public class SecurityConfig {
                         // RegexRequestMatcher는 쿼리스트링까지 포함해 비교하므로 끝에 (\?.*)? 를 둬야 ?tab=... 가 붙어도 매칭된다.
                         .requestMatchers(new RegexRequestMatcher("^/api/event/[0-9]+(\\?.*)?$", "GET")).permitAll()
                         // 비회원도 조회 가능한 공개 목록/검색/댓글 API (GET 한정)
+                        .requestMatchers(new RegexRequestMatcher("^/api/event/summary(\\?.*)?$", "GET")).permitAll()
                         .requestMatchers(new RegexRequestMatcher("^/api/event/all(\\?.*)?$", "GET")).permitAll()
                         .requestMatchers(new RegexRequestMatcher("^/api/event/search(\\?.*)?$", "GET")).permitAll()
                         .requestMatchers(new RegexRequestMatcher("^/api/event/upcoming(\\?.*)?$", "GET")).permitAll()
@@ -111,7 +110,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
 
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin(origin);
+        allowedOrigins().forEach(config::addAllowedOrigin);
         config.addAllowedMethod("*"); // 모든 메소드 허용.
         config.addAllowedHeader("*");
         config.setMaxAge(3600L);
@@ -120,5 +119,18 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
+    }
+
+    private Set<String> allowedOrigins() {
+        Set<String> allowedOrigins = new LinkedHashSet<>(DEFAULT_ALLOWED_ORIGINS);
+        if (origin == null || origin.isBlank()) {
+            return allowedOrigins;
+        }
+
+        Arrays.stream(origin.split(","))
+                .map(String::trim)
+                .filter(configuredOrigin -> !configuredOrigin.isEmpty())
+                .forEach(allowedOrigins::add);
+        return allowedOrigins;
     }
 }

--- a/run/src/main/java/com/guide/run/user/controller/LoginInfoController.java
+++ b/run/src/main/java/com/guide/run/user/controller/LoginInfoController.java
@@ -29,9 +29,6 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
 
-@CrossOrigin(origins = {"https://dev.guiderun.org", "https://guiderun.org","https://www.guiderun.org", "http://localhost:3000", "http://localhost:8080"},
-        maxAge = 3600,
-        allowCredentials = "true")
 @Tag(name = "Auth", description = "아이디 찾기, 비밀번호 재설정, 로그아웃과 관련된 인증 보조 API")
 @RestController
 @RequiredArgsConstructor

--- a/run/src/main/java/com/guide/run/user/controller/SignController.java
+++ b/run/src/main/java/com/guide/run/user/controller/SignController.java
@@ -42,9 +42,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.naming.CommunicationException;
 
 @Slf4j
-@CrossOrigin(origins = {"https://dev.guiderun.org", "https://guiderun.org","https://www.guiderun.org", "http://localhost:3000", "http://localhost:8080"},
-maxAge = 3600,
-allowCredentials = "true")
 @Tag(name = "Auth", description = "로그인, 회원가입, 토큰 재발급, 중복 확인과 회원 탈퇴를 다루는 인증 API")
 @RestController
 @RequiredArgsConstructor

--- a/run/src/test/java/com/guide/run/event/controller/EventCorsControllerTest.java
+++ b/run/src/test/java/com/guide/run/event/controller/EventCorsControllerTest.java
@@ -1,0 +1,33 @@
+package com.guide.run.event.controller;
+
+import com.guide.run.user.controller.LoginInfoController;
+import com.guide.run.user.controller.SignController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventCorsControllerTest {
+
+    @Test
+    @DisplayName("일반 API 컨트롤러는 전역 CORS 설정에 의존한다")
+    void apiControllersUseGlobalCorsConfiguration() {
+        assertThat(corsAnnotation(EventGetController.class)).isNull();
+        assertThat(corsAnnotation(EventSearchController.class)).isNull();
+        assertThat(corsAnnotation(EventMatchingController.class)).isNull();
+        assertThat(corsAnnotation(SignController.class)).isNull();
+        assertThat(corsAnnotation(LoginInfoController.class)).isNull();
+    }
+
+    @Test
+    @DisplayName("이벤트 테스트 컨트롤러는 전역 CORS 일원화 대상에서 제외한다")
+    void eventTestControllerKeepsExplicitCorsConfiguration() {
+        assertThat(corsAnnotation(EventTestController.class)).isNotNull();
+    }
+
+    private static CrossOrigin corsAnnotation(Class<?> controllerClass) {
+        return AnnotationUtils.findAnnotation(controllerClass, CrossOrigin.class);
+    }
+}

--- a/run/src/test/java/com/guide/run/global/security/config/SecurityConfigCorsTest.java
+++ b/run/src/test/java/com/guide/run/global/security/config/SecurityConfigCorsTest.java
@@ -1,0 +1,56 @@
+package com.guide.run.global.security.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurityConfigCorsTest {
+
+    private static final List<String> REQUIRED_ORIGINS = List.of(
+            "https://dev.guiderun.org",
+            "https://guiderun.org",
+            "https://www.guiderun.org"
+    );
+
+    @Test
+    @DisplayName("전역 CORS 설정은 dev/prod/www 도메인을 항상 허용한다")
+    void globalCorsAllowsRequiredOrigins() {
+        SecurityConfig securityConfig = new SecurityConfig(null);
+        ReflectionTestUtils.setField(securityConfig, "origin", "http://localhost:3000");
+
+        CorsConfiguration corsConfiguration = corsConfiguration(securityConfig, "/api/event/summary");
+
+        assertThat(corsConfiguration.getAllowedOrigins()).containsAll(REQUIRED_ORIGINS);
+        assertThat(corsConfiguration.getAllowCredentials()).isTrue();
+        assertThat(REQUIRED_ORIGINS).allSatisfy(origin ->
+                assertThat(corsConfiguration.checkOrigin(origin)).isEqualTo(origin)
+        );
+    }
+
+    @Test
+    @DisplayName("전역 CORS 설정은 환경변수로 주입한 origin도 함께 허용한다")
+    void globalCorsAllowsConfiguredOrigin() {
+        SecurityConfig securityConfig = new SecurityConfig(null);
+        ReflectionTestUtils.setField(securityConfig, "origin", "http://localhost:3000");
+
+        CorsConfiguration corsConfiguration = corsConfiguration(securityConfig, "/api/user/mypage");
+
+        assertThat(corsConfiguration.checkOrigin("http://localhost:3000")).isEqualTo("http://localhost:3000");
+    }
+
+    private CorsConfiguration corsConfiguration(SecurityConfig securityConfig, String requestUri) {
+        CorsConfigurationSource source = securityConfig.corsConfigurationSource();
+        HttpServletRequest request = new MockHttpServletRequest("OPTIONS", requestUri);
+        CorsConfiguration corsConfiguration = source.getCorsConfiguration(request);
+        assertThat(corsConfiguration).isNotNull();
+        return corsConfiguration;
+    }
+}


### PR DESCRIPTION
## 변경 배경
`https://dev.guiderun.org`에서 `/api/event/summary` 호출 시 preflight 응답에 CORS 헤더가 없어 차단되는 문제가 있었습니다. 일부 API가 `web.ignoring()`으로 빠져 전역 CORS 설정을 타지 않고, 컨트롤러별 `@CrossOrigin` 목록도 일관되지 않은 상태였습니다.

## 주요 변경 사항
- 전역 CORS 기본 허용 origin에 `https://dev.guiderun.org`, `https://guiderun.org`, `https://www.guiderun.org` 추가
- `cors.allowed-origins`를 우선 사용하고 기존 `cors.origin`도 fallback으로 유지
- 일반 API 경로를 `web.ignoring()`에서 제거해 Spring Security 전역 CORS 처리를 타도록 정리
- 일반 API 컨트롤러의 개별 `@CrossOrigin` 제거
- `/health`, `/api/event/test`, AppSmith 웹훅의 명시적 CORS 예외는 유지
- 전역 CORS 허용 목록 및 컨트롤러 CORS 일원화 테스트 추가

## 검증
- `./gradlew test --tests "*SecurityConfigCorsTest" --tests "*EventCorsControllerTest" --tests "*AppsmithUserApprovalWebhookControllerTest"`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * CORS 설정을 개별 컨트롤러에서 전역 설정으로 통합했습니다.
  * CORS 허용 오리진 관리 방식을 개선하여 설정 확장성을 높였습니다.

* **Tests**
  * CORS 설정 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->