### PR TITLE
fix: 이벤트 API 응답 계약 정합성 보정

### DIFF
--- a/run/src/main/java/com/guide/run/event/controller/EventGetController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventGetController.java
@@ -39,14 +39,14 @@ public class EventGetController {
     private final JwtProvider jwtProvider;
     private final EventGetService eventGetService;
 
-    @Operation(summary = "다가오는 이벤트 목록 조회", description = "메인/홈 화면에서 모집 중이거나 모집 예정인 가까운 이벤트 목록을 최대 10건 조회합니다. isApply는 로그인 사용자의 신청 여부를 나타냅니다.")
+    @Operation(summary = "다가오는 이벤트 목록 조회", description = "메인/홈 화면에서 사용자 유형에 맞는 가까운 이벤트 목록을 조회합니다.")
     @GetMapping("/upcoming")
     public ResponseEntity<UpcomingEventResponse> getUpcomingEvents(
-            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
-            @RequestParam(value = "page", defaultValue = "0") int page,
+            @Parameter(description = "기존 클라이언트 호환용 파라미터. 응답 계산에는 사용하지 않습니다.", example = "0")
+            @RequestParam(value = "page", required = false) Integer page,
             HttpServletRequest request) {
         String userId = jwtProvider.tryExtractUserId(request);
-        return ResponseEntity.ok(eventGetService.getUpcomingEvents(page, userId));
+        return ResponseEntity.ok(eventGetService.getUpcomingEvents(userId));
     }
 
     @Operation(summary = "이벤트 요약 조회", description = "메인페이지 상단 요약. 비회원은 올해 전체 이벤트 수와 거리, 회원은 개인 누적 참여 수와 거리도 조회합니다.")
@@ -75,17 +75,18 @@ public class EventGetController {
     public ResponseEntity<Count> getAllEventListCount(
             @Parameter(description = "탭 구분", example = "UPCOMING") @RequestParam("tab") String tab,
             @Parameter(description = "이벤트 유형 필터", example = "TOTAL") @RequestParam(value = "type", defaultValue = "TOTAL") EventType type,
-            @Parameter(description = "모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "kind", defaultValue = "RECRUIT_ALL") EventRecruitStatus kind,
+            @Parameter(description = "모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "recruitStatus", required = false) EventRecruitStatus recruitStatus,
+            @Parameter(description = "기존 클라이언트 호환용 모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "kind", required = false) EventRecruitStatus kind,
             @RequestParam(value = "cityName", required = false) CityName cityName,
             HttpServletRequest request){
         tab = normalizeTab(tab);
+        EventRecruitStatus effectiveRecruitStatus = resolveRecruitStatus(recruitStatus, kind);
         if(!tab.equals("UPCOMING") && !tab.equals("END") && !tab.equals("MY")) throw new NotValidSortException();
         if(!type.equals(TRAINING) && !type.equals(COMPETITION) && !type.equals(TOTAL)) throw new NotValidTypeException();
-        if(!kind.equals(RECRUIT_UPCOMING) && !kind.equals(RECRUIT_OPEN) && !kind.equals(RECRUIT_CLOSE)
-                && !kind.equals(RECRUIT_END) && !kind.equals(RECRUIT_ALL)) throw new NotValidKindException();
+        validateRecruitStatus(effectiveRecruitStatus);
         String userId = jwtProvider.extractUserId(request);
         return ResponseEntity.status(200).
-                body(Count.builder().count(eventGetService.getAllEventListCount(tab, type, kind, userId, cityName)).build());
+                body(Count.builder().count(eventGetService.getAllEventListCount(tab, type, effectiveRecruitStatus, userId, cityName)).build());
     }
 
     // 명세의 tab=PAST 를 내부 sort 체계(END)로 매핑. UPCOMING/MY 는 그대로 둔다.
@@ -93,23 +94,44 @@ public class EventGetController {
         return "PAST".equals(tab) ? "END" : tab;
     }
 
+    private EventRecruitStatus resolveRecruitStatus(EventRecruitStatus recruitStatus, EventRecruitStatus kind) {
+        if (recruitStatus != null) {
+            return recruitStatus;
+        }
+        if (kind != null) {
+            return kind;
+        }
+        return RECRUIT_ALL;
+    }
+
+    private void validateRecruitStatus(EventRecruitStatus recruitStatus) {
+        if(!recruitStatus.equals(RECRUIT_UPCOMING) && !recruitStatus.equals(RECRUIT_OPEN) && !recruitStatus.equals(RECRUIT_CLOSE)
+                && !recruitStatus.equals(RECRUIT_END) && !recruitStatus.equals(RECRUIT_ALL)) throw new NotValidKindException();
+    }
+
+    private int normalizePage(int page) {
+        return Math.max(page, 1);
+    }
+
     @Operation(summary = "전체 이벤트 목록 조회", description = "전체 이벤트 탭에서 선택한 필터와 페이지네이션 조건에 맞는 이벤트 목록을 조회합니다.")
     @GetMapping("/all")
     public ResponseEntity<AllEventResponse> getAllEventList(
             @Parameter(description = "탭 구분", example = "UPCOMING") @RequestParam("tab") String tab,
             @Parameter(description = "이벤트 유형 필터", example = "TOTAL") @RequestParam(value = "type", defaultValue = "TOTAL") EventType type,
-            @Parameter(description = "모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "kind", defaultValue = "RECRUIT_ALL") EventRecruitStatus kind,
+            @Parameter(description = "모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "recruitStatus", required = false) EventRecruitStatus recruitStatus,
+            @Parameter(description = "기존 클라이언트 호환용 모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "kind", required = false) EventRecruitStatus kind,
             @RequestParam(value = "cityName", required = false) CityName cityName,
-            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(value = "page", defaultValue = "0") int page,
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1") @RequestParam(value = "page", defaultValue = "1") int page,
             HttpServletRequest request){
         tab = normalizeTab(tab);
+        EventRecruitStatus effectiveRecruitStatus = resolveRecruitStatus(recruitStatus, kind);
         if(!tab.equals("UPCOMING") && !tab.equals("END") && !tab.equals("MY")) throw new NotValidSortException();
         if(!type.equals(TRAINING) && !type.equals(COMPETITION) && !type.equals(TOTAL)) throw new NotValidTypeException();
-        if(!kind.equals(RECRUIT_UPCOMING) && !kind.equals(RECRUIT_OPEN) && !kind.equals(RECRUIT_CLOSE)
-                && !kind.equals(RECRUIT_END) && !kind.equals(RECRUIT_ALL)) throw new NotValidKindException();
+        validateRecruitStatus(effectiveRecruitStatus);
         String userId = jwtProvider.tryExtractUserId(request);
-        int start = page * PAGE_SIZE;
+        int normalizedPage = normalizePage(page);
+        int start = (normalizedPage - 1) * PAGE_SIZE;
         return ResponseEntity.status(200).
-                body(eventGetService.getAllEventList(PAGE_SIZE, start, tab, type, kind, userId, cityName));
+                body(eventGetService.getAllEventList(PAGE_SIZE, start, normalizedPage, tab, type, effectiveRecruitStatus, userId, cityName));
     }
 }

--- a/run/src/main/java/com/guide/run/event/controller/EventSearchController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventSearchController.java
@@ -44,15 +44,18 @@ public class EventSearchController {
             @Parameter(description = "검색어", example = "상계천") @RequestParam(value = "keyword", defaultValue = "") String keyword,
             @Parameter(description = "탭 구분", example = "UPCOMING") @RequestParam(value = "tab", defaultValue = "UPCOMING") String tab,
             @Parameter(description = "이벤트 유형 필터", example = "TOTAL") @RequestParam(value = "type", defaultValue = "TOTAL") EventType type,
-            @Parameter(description = "모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "kind", defaultValue = "RECRUIT_ALL") EventRecruitStatus kind,
+            @Parameter(description = "모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "recruitStatus", required = false) EventRecruitStatus recruitStatus,
+            @Parameter(description = "기존 클라이언트 호환용 모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "kind", required = false) EventRecruitStatus kind,
             @RequestParam(value = "cityName", required = false) CityName cityName,
-            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(value = "page", defaultValue = "0") int page,
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1") @RequestParam(value = "page", defaultValue = "1") int page,
             HttpServletRequest request) {
         tab = normalizeTab(tab);
-        validateParams(tab, type, kind);
+        EventRecruitStatus effectiveRecruitStatus = resolveRecruitStatus(recruitStatus, kind);
+        validateParams(tab, type, effectiveRecruitStatus);
         String privateId = extracted(request);
-        int start = page * PAGE_SIZE;
-        return eventSearchService.getSearchAllEvents(start, PAGE_SIZE, keyword, tab, type, kind, privateId, cityName);
+        int normalizedPage = normalizePage(page);
+        int start = (normalizedPage - 1) * PAGE_SIZE;
+        return eventSearchService.getSearchAllEvents(start, PAGE_SIZE, normalizedPage, keyword, tab, type, effectiveRecruitStatus, privateId, cityName);
     }
 
     @Operation(summary = "이벤트 검색 개수 조회", description = "이벤트 검색 화면에서 키워드 및 탭 조건 기준 검색 결과 개수를 조회합니다.")
@@ -61,13 +64,15 @@ public class EventSearchController {
             @Parameter(description = "검색어", example = "상계천") @RequestParam(value = "keyword", defaultValue = "") String keyword,
             @Parameter(description = "탭 구분", example = "UPCOMING") @RequestParam(value = "tab", defaultValue = "UPCOMING") String tab,
             @Parameter(description = "이벤트 유형 필터", example = "TOTAL") @RequestParam(value = "type", defaultValue = "TOTAL") EventType type,
-            @Parameter(description = "모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "kind", defaultValue = "RECRUIT_ALL") EventRecruitStatus kind,
+            @Parameter(description = "모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "recruitStatus", required = false) EventRecruitStatus recruitStatus,
+            @Parameter(description = "기존 클라이언트 호환용 모집 상태 필터", example = "RECRUIT_ALL") @RequestParam(value = "kind", required = false) EventRecruitStatus kind,
             @RequestParam(value = "cityName", required = false) CityName cityName,
             HttpServletRequest request) {
         tab = normalizeTab(tab);
-        validateParams(tab, type, kind);
+        EventRecruitStatus effectiveRecruitStatus = resolveRecruitStatus(recruitStatus, kind);
+        validateParams(tab, type, effectiveRecruitStatus);
         String privateId = extracted(request);
-        return eventSearchService.getSearchAllEventsCount(keyword, tab, type, kind, privateId, cityName);
+        return eventSearchService.getSearchAllEventsCount(keyword, tab, type, effectiveRecruitStatus, privateId, cityName);
     }
 
     // 명세의 tab=PAST 를 내부 sort 체계(END)로 매핑. UPCOMING/MY 는 그대로 둔다.
@@ -80,6 +85,20 @@ public class EventSearchController {
         if (!type.equals(TRAINING) && !type.equals(COMPETITION) && !type.equals(TOTAL)) throw new NotValidTypeException();
         if (!kind.equals(RECRUIT_UPCOMING) && !kind.equals(RECRUIT_OPEN) && !kind.equals(RECRUIT_CLOSE)
                 && !kind.equals(RECRUIT_END) && !kind.equals(RECRUIT_ALL)) throw new NotValidKindException();
+    }
+
+    private EventRecruitStatus resolveRecruitStatus(EventRecruitStatus recruitStatus, EventRecruitStatus kind) {
+        if (recruitStatus != null) {
+            return recruitStatus;
+        }
+        if (kind != null) {
+            return kind;
+        }
+        return RECRUIT_ALL;
+    }
+
+    private int normalizePage(int page) {
+        return Math.max(page, 1);
     }
 
     // 비회원도 검색 가능. 토큰이 있으면 사용자 존재를 검증하고, 없으면 null(비회원)로 처리한다.

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEvent.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEvent.java
@@ -10,17 +10,30 @@ import java.util.Locale;
 
 @Getter
 public class AllEvent {
-    private Long eventId;
-    private EventType eventType;
-    private String name;
-    private String startDate;
+    private Long id;
     private EventRecruitStatus recruitStatus;
+    private String name;
+    private EventType type;
+    private String dateText;
 
     public AllEvent(Long eventId, EventType eventType, String name, LocalDateTime startDate, EventRecruitStatus recruitStatus) {
-        this.eventId = eventId;
-        this.eventType = eventType;
+        this.id = eventId;
+        this.recruitStatus = toResponseRecruitStatus(recruitStatus);
         this.name = name;
-        this.startDate = startDate.getYear()+"."+ startDate.getMonthValue()+"."+ startDate.getDayOfMonth()+" "+ startDate.getDayOfWeek().getDisplayName(TextStyle.NARROW, Locale.KOREA);
-        this.recruitStatus = recruitStatus;
+        this.type = eventType;
+        this.dateText = String.format(
+                "%04d. %02d. %02d %s",
+                startDate.getYear(),
+                startDate.getMonthValue(),
+                startDate.getDayOfMonth(),
+                startDate.getDayOfWeek().getDisplayName(TextStyle.NARROW, Locale.KOREA)
+        );
+    }
+
+    private EventRecruitStatus toResponseRecruitStatus(EventRecruitStatus recruitStatus) {
+        if (recruitStatus == EventRecruitStatus.RECRUIT_END) {
+            return EventRecruitStatus.RECRUIT_CLOSE;
+        }
+        return recruitStatus;
     }
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEventResponse.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEventResponse.java
@@ -25,7 +25,31 @@ public class AllEventResponse {
     @NoArgsConstructor
     @Schema(description = "페이지네이션 정보")
     public static class Pagination {
+        @Schema(description = "현재 페이지 번호(1부터 시작)", example = "1")
+        private int page;
+
+        @Schema(description = "페이지 크기", example = "10")
+        private int size;
+
         @Schema(description = "필터 조건에 해당하는 전체 이벤트 수", example = "42")
         private long totalCount;
+
+        @Schema(description = "전체 페이지 수", example = "5")
+        private int totalPages;
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        private boolean hasNext;
+
+        public static Pagination of(int page, int size, long totalCount) {
+            int normalizedPage = Math.max(page, 1);
+            int totalPages = size > 0 ? (int) Math.ceil((double) totalCount / size) : 0;
+            return Pagination.builder()
+                    .page(normalizedPage)
+                    .size(size)
+                    .totalCount(totalCount)
+                    .totalPages(totalPages)
+                    .hasNext(normalizedPage < totalPages)
+                    .build();
+        }
     }
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/UpcomingEventResponse.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/UpcomingEventResponse.java
@@ -1,15 +1,82 @@
 package com.guide.run.event.entity.dto.response.get;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.guide.run.user.entity.type.UserType;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class UpcomingEventResponse {
-    private List<UpcomingEvent> items;
+    private ViewerType viewerType;
+    private List<?> items;
 
+    public static UpcomingEventResponse guest(List<GuestItem> items) {
+        return UpcomingEventResponse.builder()
+                .viewerType(ViewerType.GUEST)
+                .items(items)
+                .build();
+    }
+
+    public static UpcomingEventResponse member(List<MemberItem> items) {
+        return UpcomingEventResponse.builder()
+                .viewerType(ViewerType.MEMBER)
+                .items(items)
+                .build();
+    }
+
+    public enum ViewerType {
+        GUEST,
+        MEMBER
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class GuestItem {
+        private Long id;
+        private String name;
+        @Getter(AccessLevel.NONE)
+        private int dDay;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        private LocalDate date;
+
+        @JsonProperty("dDay")
+        public int getDDay() {
+            return dDay;
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class MemberItem {
+        private Long id;
+        private String name;
+        @Getter(AccessLevel.NONE)
+        private int dDay;
+        private String place;
+        private String scheduleText;
+        private List<PartnerItem> myPartner;
+
+        @JsonProperty("dDay")
+        public int getDDay() {
+            return dDay;
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class PartnerItem {
+        private UserType type;
+        private String name;
+    }
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/search/SearchAllEvent.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/search/SearchAllEvent.java
@@ -10,9 +10,9 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class SearchAllEvent {
-    private Long eventId;
-    private EventType eventType;
-    private String name;
-    private String startDate;
+    private Long id;
     private EventRecruitStatus recruitStatus;
-}
+    private String name;
+    private EventType type;
+    private String dateText;
+}

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/search/SearchAllEventList.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/search/SearchAllEventList.java
@@ -20,6 +20,22 @@ public class SearchAllEventList {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Pagination {
+        private int page;
+        private int size;
         private long totalCount;
+        private int totalPages;
+        private boolean hasNext;
+
+        public static Pagination of(int page, int size, long totalCount) {
+            int normalizedPage = Math.max(page, 1);
+            int totalPages = size > 0 ? (int) Math.ceil((double) totalCount / size) : 0;
+            return Pagination.builder()
+                    .page(normalizedPage)
+                    .size(size)
+                    .totalCount(totalCount)
+                    .totalPages(totalPages)
+                    .hasNext(normalizedPage < totalPages)
+                    .build();
+        }
     }
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryCustom.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryCustom.java
@@ -23,6 +23,8 @@ public interface EventRepositoryCustom {
     List<Event> getSchedulerEvent();
     List<Event> getSchedulerRecruit();
 
+    long countEventList(EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
+    long countUpcomingEventList(EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     List<AllEvent> getAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     List<AllEvent> upcomingGetAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
 
@@ -33,6 +35,7 @@ public interface EventRepositoryCustom {
     List<AllEvent> getSearchEventList(int limit, int start, String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     List<AllEvent> upcomingGetSearchEventList(int limit, int start, String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     List<AllEvent> getMySearchEventList(int limit, int start, String title, EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId, CityName cityName);
+    long upcomingGetSearchEventListCount(String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     long getSearchEventListCount(String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     long getMySearchEventListCount(String title, EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId, CityName cityName);
 

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -195,6 +195,35 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
     }
 
     @Override
+    public long countEventList(EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName) {
+        Long result = queryFactory.select(event.count())
+                .from(event)
+                .where(checkByKind(eventRecruitStatus)
+                        .and(checkByType(eventType))
+                        .and(event.isApprove.eq(true))
+                        .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
+                )
+                .fetchOne();
+        return result != null ? result : 0L;
+    }
+
+    @Override
+    public long countUpcomingEventList(EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName) {
+        Long result = queryFactory.select(event.count())
+                .from(event)
+                .where(checkByKind(eventRecruitStatus)
+                        .and(checkByType(eventType))
+                        .and(event.isApprove.eq(true))
+                        .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
+                        .and(checkByUpcomingDate())
+                )
+                .fetchOne();
+        return result != null ? result : 0L;
+    }
+
+    @Override
     public List<AllEvent> getAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus,CityName cityName) {
         return queryFactory.select(Projections.constructor(AllEvent.class,
                         event.id.as("eventId"),
@@ -207,6 +236,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(checkByType(eventType))
                         .and(event.isApprove.eq(true))
                         .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
                 )
                 .orderBy(event.startTime.desc())
                 .offset(start)
@@ -226,6 +256,8 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(checkByType(eventType))
                         .and(event.isApprove.eq(true))
                         .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
+                        .and(checkByUpcomingDate())
                 )
                 .orderBy(event.startTime.asc())
                 .offset(start)
@@ -267,6 +299,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(checkByType(eventType))
                         .and(event.isApprove.eq(true))
                         .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
                         .and(checkByTitle(title))
                 )
                 .orderBy(event.startTime.desc())
@@ -288,7 +321,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(checkByType(eventType))
                         .and(event.isApprove.eq(true))
                         .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
                         .and(checkByTitle(title))
+                        .and(checkByUpcomingDate())
                 )
                 .orderBy(event.startTime.asc())
                 .offset(start)
@@ -320,6 +355,22 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
     }
 
     @Override
+    public long upcomingGetSearchEventListCount(String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName) {
+        Long result = queryFactory.select(event.count())
+                .from(event)
+                .where(checkByKind(eventRecruitStatus)
+                        .and(checkByType(eventType))
+                        .and(event.isApprove.eq(true))
+                        .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
+                        .and(checkByTitle(title))
+                        .and(checkByUpcomingDate())
+                )
+                .fetchOne();
+        return result != null ? result : 0L;
+    }
+
+    @Override
     public long getSearchEventListCount(String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName) {
         return queryFactory.select(event.count())
                 .from(event)
@@ -327,6 +378,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(checkByType(eventType))
                         .and(event.isApprove.eq(true))
                         .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
                         .and(checkByTitle(title))
                 )
                 .fetchOne();
@@ -455,6 +507,14 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
         } else{
             return new BooleanBuilder(event.cityName.eq(CityName.SEOUL));
         }
+    }
+
+    private BooleanBuilder checkByUpcomingDate() {
+        return new BooleanBuilder(event.startTime.goe(LocalDate.now().atStartOfDay()));
+    }
+
+    private BooleanBuilder checkByPublicEvent() {
+        return new BooleanBuilder(event.isPrivate.eq(false));
     }
 
     private BooleanBuilder checkByKind(EventRecruitStatus kind){

--- a/run/src/main/java/com/guide/run/event/service/EventGetService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventGetService.java
@@ -3,31 +3,52 @@ package com.guide.run.event.service;
 import com.guide.run.event.entity.Event;
 import com.guide.run.event.entity.EventForm;
 import com.guide.run.event.entity.dto.response.get.*;
-import java.time.LocalDate;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.CityName;
+import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import com.guide.run.global.exception.event.logic.NotValidKindException;
 import com.guide.run.global.exception.event.logic.NotValidSortException;
+import com.guide.run.partner.entity.matching.Matching;
+import com.guide.run.partner.entity.matching.repository.MatchingRepository;
+import com.guide.run.user.entity.type.Role;
+import com.guide.run.user.entity.type.UserType;
+import com.guide.run.user.entity.user.User;
+import com.guide.run.user.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.TextStyle;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.guide.run.event.entity.type.EventRecruitStatus.*;
 import static com.guide.run.event.entity.type.EventType.TOTAL;
+import static java.time.temporal.ChronoUnit.DAYS;
 
 @Service
 @RequiredArgsConstructor
 public class EventGetService {
+    private static final int UPCOMING_GUEST_LIMIT = 5;
+    private static final int UPCOMING_MEMBER_LIMIT = 5;
+    private static final ZoneId SERVICE_ZONE = ZoneId.of("Asia/Seoul");
+
     private final EventRepository eventRepository;
     private final EventFormRepository eventFormRepository;
+    private final UserRepository userRepository;
+    private final MatchingRepository matchingRepository;
 
 
     public MyEventResponse getMyEvent(String sort, int year,String privateId) {
@@ -44,43 +65,9 @@ public class EventGetService {
 
     public long getAllEventListCount(String sort, EventType type, EventRecruitStatus kind, String privateId, CityName cityName) {
         if (sort.equals("UPCOMING")) {
-            if (type.equals(TOTAL)) {
-                if (kind.equals(RECRUIT_ALL)) {
-                    if (cityName == null) {
-                        return eventRepository.countByRecruitStatusNotAndIsApprove(RECRUIT_END, true);
-                    }
-                    return eventRepository.countByRecruitStatusNotAndIsApproveAndCityName(RECRUIT_END, true, cityName);
-                } else {
-                    if (cityName == null) {
-                        return eventRepository.countByRecruitStatusAndIsApprove(kind, true);
-                    }
-                    return eventRepository.countByRecruitStatusAndIsApproveAndCityName(kind, true, cityName);
-                }
-            } else {
-                if (kind.equals(RECRUIT_ALL)) {
-                    if (cityName == null) {
-                        return eventRepository.countByTypeAndRecruitStatusNotAndIsApprove(type, RECRUIT_END, true);
-                    }
-                    return eventRepository.countByTypeAndRecruitStatusNotAndIsApproveAndCityName(type, RECRUIT_END, true, cityName);
-                } else {
-                    if (cityName == null) {
-                        return eventRepository.countByTypeAndRecruitStatusAndIsApprove(type, kind, true);
-                    }
-                    return eventRepository.countByTypeAndRecruitStatusAndIsApproveAndCityName(type, kind, true, cityName);
-                }
-            }
+            return eventRepository.countUpcomingEventList(type.equals(TOTAL) ? null : type, kind, cityName);
         } else if (sort.equals("END")) {
-            if (type.equals(TOTAL)) {
-                if (cityName == null) {
-                    return eventRepository.countByRecruitStatusAndIsApprove(RECRUIT_END, true);
-                }
-                return eventRepository.countByRecruitStatusAndIsApproveAndCityName(RECRUIT_END, true, cityName);
-            } else {
-                if (cityName == null) {
-                    return eventRepository.countByTypeAndRecruitStatusAndIsApprove(type, RECRUIT_END, true);
-                }
-                return eventRepository.countByTypeAndRecruitStatusAndIsApproveAndCityName(type, RECRUIT_END, true, cityName);
-            }
+            return eventRepository.countEventList(type.equals(TOTAL) ? null : type, RECRUIT_END, cityName);
         } else {
             if (type.equals(TOTAL)) {
                 if (kind.equals(RECRUIT_ALL)) {
@@ -103,6 +90,7 @@ public class EventGetService {
 
     public AllEventResponse getAllEventList(int limit,
                                             int start,
+                                            int page,
                                             String sort,
                                             EventType type,
                                             EventRecruitStatus kind,
@@ -155,41 +143,168 @@ public class EventGetService {
 
         return AllEventResponse.builder()
                 .items(allEvents)
-                .pagination(AllEventResponse.Pagination.builder().totalCount(totalCount).build())
+                .pagination(AllEventResponse.Pagination.of(page, limit, totalCount))
                 .build();
     }
 
-    public UpcomingEventResponse getUpcomingEvents(int page, String privateId) {
-        final int PAGE_SIZE = 10;
-        int start = page * PAGE_SIZE;
+    public UpcomingEventResponse getUpcomingEvents(String privateId) {
+        User member = findApprovedMember(privateId);
+        if (member == null) {
+            return getGuestUpcomingEvents();
+        }
+        return getMemberUpcomingEvents(member);
+    }
 
-        List<AllEvent> allEvents = eventRepository.upcomingGetAllEventList(PAGE_SIZE, start, null, RECRUIT_ALL, null);
-
+    private UpcomingEventResponse getGuestUpcomingEvents() {
+        List<AllEvent> allEvents = eventRepository.upcomingGetAllEventList(UPCOMING_GUEST_LIMIT, 0, null, RECRUIT_ALL, null);
         if (allEvents.isEmpty()) {
-            return UpcomingEventResponse.builder().items(List.of()).build();
+            return UpcomingEventResponse.guest(List.of());
         }
 
-        List<Long> eventIds = allEvents.stream().map(AllEvent::getEventId).collect(Collectors.toList());
-
-        Set<Long> appliedEventIds = eventFormRepository.findAllByPrivateIdAndEventIdIn(privateId, eventIds)
-                .stream().map(EventForm::getEventId).collect(Collectors.toSet());
-
+        List<Long> eventIds = allEvents.stream().map(AllEvent::getId).collect(Collectors.toList());
         Map<Long, Event> eventMap = eventRepository.findAllById(eventIds).stream()
-                .collect(Collectors.toMap(Event::getId, e -> e));
+                .collect(Collectors.toMap(Event::getId, event -> event));
 
-        List<UpcomingEvent> items = allEvents.stream().map(ae -> {
-            Event ev = eventMap.get(ae.getEventId());
-            return UpcomingEvent.builder()
-                    .eventId(ae.getEventId())
-                    .eventType(ae.getEventType())
-                    .name(ae.getName())
-                    .isApply(appliedEventIds.contains(ae.getEventId()))
-                    .date(ev != null ? ev.getStartTime().toLocalDate() : null)
-                    .recruitStatus(ae.getRecruitStatus())
-                    .build();
-        }).collect(Collectors.toList());
+        List<UpcomingEventResponse.GuestItem> items = allEvents.stream()
+                .map(allEvent -> eventMap.get(allEvent.getId()))
+                .filter(Objects::nonNull)
+                .map(event -> UpcomingEventResponse.GuestItem.builder()
+                        .id(event.getId())
+                        .name(event.getName())
+                        .dDay(getDDay(event.getStartTime().toLocalDate()))
+                        .date(event.getStartTime().toLocalDate())
+                        .build())
+                .collect(Collectors.toList());
 
-        return UpcomingEventResponse.builder().items(items).build();
+        return UpcomingEventResponse.guest(items);
+    }
+
+    private UpcomingEventResponse getMemberUpcomingEvents(User member) {
+        String privateId = member.getPrivateId();
+        Set<Long> appliedEventIds = eventFormRepository.findAllByPrivateId(privateId).stream()
+                .filter(this::isActiveApplication)
+                .map(EventForm::getEventId)
+                .collect(Collectors.toSet());
+
+        Map<Long, Event> eventMap = new LinkedHashMap<>();
+        eventRepository.findAllById(appliedEventIds).forEach(event -> eventMap.put(event.getId(), event));
+        eventRepository.findAllByOrganizer(privateId).forEach(event -> eventMap.put(event.getId(), event));
+
+        List<UpcomingEventResponse.MemberItem> items = eventMap.values().stream()
+                .filter(this::isMemberUpcomingEvent)
+                .sorted(Comparator.comparing(Event::getStartTime))
+                .limit(UPCOMING_MEMBER_LIMIT)
+                .map(event -> {
+                    boolean isOrganizer = privateId.equals(event.getOrganizer());
+                    List<UpcomingEventResponse.PartnerItem> partners = isOrganizer ? List.of() : findPartners(event, member);
+                    return UpcomingEventResponse.MemberItem.builder()
+                            .id(event.getId())
+                            .name(event.getName())
+                            .dDay(getDDay(event.getStartTime().toLocalDate()))
+                            .place(event.getPlace())
+                            .scheduleText(formatScheduleText(event))
+                            .myPartner(partners.isEmpty() ? null : partners)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return UpcomingEventResponse.member(items);
+    }
+
+    private User findApprovedMember(String privateId) {
+        if (privateId == null) {
+            return null;
+        }
+        return userRepository.findUserByPrivateId(privateId)
+                .filter(user -> user.getRole() == Role.ROLE_USER
+                        || user.getRole() == Role.ROLE_COACH
+                        || user.getRole() == Role.ROLE_ADMIN)
+                .orElse(null);
+    }
+
+    private boolean isActiveApplication(EventForm eventForm) {
+        return eventForm.getStatus() == null || eventForm.getStatus() == EventFormStatus.APPLIED;
+    }
+
+    private boolean isMemberUpcomingEvent(Event event) {
+        return event != null
+                && event.isApprove()
+                && event.getRecruitStatus() != RECRUIT_END
+                && event.getStartTime() != null
+                && !event.getStartTime().isBefore(todayStart());
+    }
+
+    private LocalDateTime todayStart() {
+        return LocalDate.now(SERVICE_ZONE).atStartOfDay();
+    }
+
+    private int getDDay(LocalDate date) {
+        return (int) DAYS.between(LocalDate.now(SERVICE_ZONE), date);
+    }
+
+    private List<UpcomingEventResponse.PartnerItem> findPartners(Event event, User member) {
+        if (member.getType() == UserType.GUIDE) {
+            Matching matching = matchingRepository.findByEventIdAndGuideId(event.getId(), member.getPrivateId());
+            if (matching == null || matching.getViId() == null) {
+                return List.of();
+            }
+            return toPartnerItems(List.of(matching.getViId()));
+        }
+        if (member.getType() == UserType.VI) {
+            List<String> guideIds = matchingRepository.findAllByEventIdAndViId(event.getId(), member.getPrivateId()).stream()
+                    .map(Matching::getGuideId)
+                    .collect(Collectors.toList());
+            return toPartnerItems(guideIds);
+        }
+        return List.of();
+    }
+
+    private List<UpcomingEventResponse.PartnerItem> toPartnerItems(List<String> partnerPrivateIds) {
+        List<String> ids = partnerPrivateIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, User> userMap = userRepository.findAllById(ids).stream()
+                .collect(Collectors.toMap(User::getPrivateId, user -> user, (left, right) -> left, LinkedHashMap::new));
+
+        return ids.stream()
+                .map(userMap::get)
+                .filter(Objects::nonNull)
+                .map(user -> UpcomingEventResponse.PartnerItem.builder()
+                        .type(user.getType())
+                        .name(user.getName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private String formatScheduleText(Event event) {
+        LocalDateTime startTime = event.getStartTime();
+        return String.format(
+                "%d년 %d월 %d일 (%s) %s ~ %s",
+                startTime.getYear(),
+                startTime.getMonthValue(),
+                startTime.getDayOfMonth(),
+                startTime.getDayOfWeek().getDisplayName(TextStyle.NARROW, Locale.KOREA),
+                formatKoreanTime(startTime),
+                formatKoreanTime(event.getEndTime())
+        );
+    }
+
+    private String formatKoreanTime(LocalDateTime time) {
+        if (time == null) {
+            return "";
+        }
+        String period = time.getHour() < 12 ? "오전" : "오후";
+        int hour = time.getHour() % 12;
+        int displayHour = hour == 0 ? 12 : hour;
+        if (time.getMinute() == 0) {
+            return period + " " + displayHour + "시";
+        }
+        return period + " " + displayHour + "시 " + time.getMinute() + "분";
     }
 
     public EventsSummaryGetResponse getEventsSummary(String userId) {

--- a/run/src/main/java/com/guide/run/event/service/EventSearchService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventSearchService.java
@@ -28,9 +28,9 @@ public class EventSearchService {
     public long getSearchAllEventsCountValue(String title, String sort, EventType type, EventRecruitStatus kind, String privateId, CityName cityName) {
         if (sort.equals("UPCOMING")) {
             if (type.equals(TOTAL)) {
-                return eventRepository.getSearchEventListCount(title, null, kind.equals(RECRUIT_ALL) ? RECRUIT_ALL : kind, cityName);
+                return eventRepository.upcomingGetSearchEventListCount(title, null, kind.equals(RECRUIT_ALL) ? RECRUIT_ALL : kind, cityName);
             } else {
-                return eventRepository.getSearchEventListCount(title, type, kind.equals(RECRUIT_ALL) ? RECRUIT_ALL : kind, cityName);
+                return eventRepository.upcomingGetSearchEventListCount(title, type, kind.equals(RECRUIT_ALL) ? RECRUIT_ALL : kind, cityName);
             }
         } else if (sort.equals("END")) {
             if (type.equals(TOTAL)) {
@@ -61,7 +61,7 @@ public class EventSearchService {
                 .build();
     }
 
-    public SearchAllEventList getSearchAllEvents(int start, int limit, String title, String sort, EventType type, EventRecruitStatus kind, String privateId, CityName cityName) {
+    public SearchAllEventList getSearchAllEvents(int start, int limit, int page, String title, String sort, EventType type, EventRecruitStatus kind, String privateId, CityName cityName) {
         List<AllEvent> allEvents = new ArrayList<>();
 
         if (sort.equals("UPCOMING")) {
@@ -97,17 +97,17 @@ public class EventSearchService {
 
         List<SearchAllEvent> items = allEvents.stream()
                 .map(ae -> SearchAllEvent.builder()
-                        .eventId(ae.getEventId())
-                        .eventType(ae.getEventType())
-                        .name(ae.getName())
-                        .startDate(ae.getStartDate())
+                        .id(ae.getId())
                         .recruitStatus(ae.getRecruitStatus())
+                        .name(ae.getName())
+                        .type(ae.getType())
+                        .dateText(ae.getDateText())
                         .build())
                 .collect(Collectors.toList());
 
         return SearchAllEventList.builder()
                 .items(items)
-                .pagination(SearchAllEventList.Pagination.builder().totalCount(totalCount).build())
+                .pagination(SearchAllEventList.Pagination.of(page, limit, totalCount))
                 .build();
     }
 }

--- a/run/src/main/java/com/guide/run/global/exception/auth/AuthAuthorizeExceptionAdvice.java
+++ b/run/src/main/java/com/guide/run/global/exception/auth/AuthAuthorizeExceptionAdvice.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RequiredArgsConstructor
 @RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class AuthAuthorizeExceptionAdvice {
     private final MessageSource messageSource;
     private final ResponseService responseService;

--- a/run/src/main/java/com/guide/run/global/exception/event/EventResourceExceptionAdvice.java
+++ b/run/src/main/java/com/guide/run/global/exception/event/EventResourceExceptionAdvice.java
@@ -8,6 +8,8 @@ import com.guide.run.global.service.ResponseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RequiredArgsConstructor
 @RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class EventResourceExceptionAdvice {
     private final MessageSource messageSource;
     private final ResponseService responseService;

--- a/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
+++ b/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
@@ -51,7 +51,6 @@ public class SecurityConfig {
                     .requestMatchers("/api/sms/**")
                     .requestMatchers("/api/accountId")
                     .requestMatchers("/api/new-password")
-                    .requestMatchers("/api/event/summary")
                     .requestMatchers("/tmp/**")
                     .requestMatchers("/api/login")
                     .requestMatchers("/v3/api-docs/**")
@@ -81,6 +80,7 @@ public class SecurityConfig {
                         // RegexRequestMatcher는 쿼리스트링까지 포함해 비교하므로 끝에 (\?.*)? 를 둬야 ?tab=... 가 붙어도 매칭된다.
                         .requestMatchers(new RegexRequestMatcher("^/api/event/[0-9]+(\\?.*)?$", "GET")).permitAll()
                         // 비회원도 조회 가능한 공개 목록/검색/댓글 API (GET 한정)
+                        .requestMatchers(new RegexRequestMatcher("^/api/event/summary(\\?.*)?$", "GET")).permitAll()
                         .requestMatchers(new RegexRequestMatcher("^/api/event/all(\\?.*)?$", "GET")).permitAll()
                         .requestMatchers(new RegexRequestMatcher("^/api/event/search(\\?.*)?$", "GET")).permitAll()
                         .requestMatchers(new RegexRequestMatcher("^/api/event/upcoming(\\?.*)?$", "GET")).permitAll()

--- a/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
+++ b/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
@@ -19,14 +19,26 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 
 
 @RequiredArgsConstructor
 @Configuration
 @EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
+    private static final List<String> DEFAULT_ALLOWED_ORIGINS = List.of(
+            "https://dev.guiderun.org",
+            "https://guiderun.org",
+            "https://www.guiderun.org"
+    );
+
     private final JwtProvider jwtProvider;
-     @Value("${cors.origin}")
+
+    @Value("${cors.allowed-origins:${cors.origin:}}")
     private String origin;
 
     @Bean
@@ -43,20 +55,7 @@ public class SecurityConfig {
                     .requestMatchers("/health")
                     .requestMatchers("/webhook/tosspayments")
                     .requestMatchers("/webhook/appsmith/user-approval")
-                    .requestMatchers("/favicon.ico")
-                    .requestMatchers("/member-upload")
-                    .requestMatchers("/event-upload")
-                    .requestMatchers("/attendance-upload")
-                    .requestMatchers("/api/oauth/**")
-                    .requestMatchers("/api/sms/**")
-                    .requestMatchers("/api/accountId")
-                    .requestMatchers("/api/new-password")
-                    .requestMatchers("/tmp/**")
-                    .requestMatchers("/api/login")
-                    .requestMatchers("/v3/api-docs/**")
-                    .requestMatchers("/v3/api-docs")
-                    .requestMatchers("/swagger-ui/**")
-                    .requestMatchers("/swagger-ui.html");
+                    .requestMatchers("/favicon.ico");
         };
     }
     @Bean
@@ -111,7 +110,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
 
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin(origin);
+        allowedOrigins().forEach(config::addAllowedOrigin);
         config.addAllowedMethod("*"); // 모든 메소드 허용.
         config.addAllowedHeader("*");
         config.setMaxAge(3600L);
@@ -120,5 +119,18 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
+    }
+
+    private Set<String> allowedOrigins() {
+        Set<String> allowedOrigins = new LinkedHashSet<>(DEFAULT_ALLOWED_ORIGINS);
+        if (origin == null || origin.isBlank()) {
+            return allowedOrigins;
+        }
+
+        Arrays.stream(origin.split(","))
+                .map(String::trim)
+                .filter(configuredOrigin -> !configuredOrigin.isEmpty())
+                .forEach(allowedOrigins::add);
+        return allowedOrigins;
     }
 }

--- a/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
@@ -1,0 +1,67 @@
+package com.guide.run.event.service;
+
+import com.guide.run.event.entity.repository.EventFormRepository;
+import com.guide.run.event.entity.repository.EventRepository;
+import com.guide.run.event.entity.type.EventRecruitStatus;
+import com.guide.run.event.entity.type.EventType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventGetServiceTest {
+
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private EventFormRepository eventFormRepository;
+
+    @InjectMocks
+    private EventGetService eventGetService;
+
+    @Test
+    @DisplayName("예정 이벤트 카운트는 시작일 필터가 포함된 전용 쿼리를 사용한다")
+    void getAllEventListCountUsesUpcomingCountQuery() {
+        when(eventRepository.countUpcomingEventList(null, EventRecruitStatus.RECRUIT_ALL, null))
+                .thenReturn(7L);
+
+        long count = eventGetService.getAllEventListCount(
+                "UPCOMING",
+                EventType.TOTAL,
+                EventRecruitStatus.RECRUIT_ALL,
+                null,
+                null
+        );
+
+        assertThat(count).isEqualTo(7L);
+        verify(eventRepository).countUpcomingEventList(null, EventRecruitStatus.RECRUIT_ALL, null);
+        verify(eventRepository, never()).countByRecruitStatusNotAndIsApprove(EventRecruitStatus.RECRUIT_END, true);
+    }
+
+    @Test
+    @DisplayName("지난 이벤트 카운트는 공개 이벤트 전용 쿼리를 사용한다")
+    void getAllEventListCountUsesPublicEventCountQueryForEndedEvents() {
+        when(eventRepository.countEventList(null, EventRecruitStatus.RECRUIT_END, null))
+                .thenReturn(5L);
+
+        long count = eventGetService.getAllEventListCount(
+                "END",
+                EventType.TOTAL,
+                EventRecruitStatus.RECRUIT_ALL,
+                null,
+                null
+        );
+
+        assertThat(count).isEqualTo(5L);
+        verify(eventRepository).countEventList(null, EventRecruitStatus.RECRUIT_END, null);
+        verify(eventRepository, never()).countByRecruitStatusAndIsApprove(EventRecruitStatus.RECRUIT_END, true);
+    }
+}

--- a/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
@@ -1,0 +1,114 @@
+package com.guide.run.event.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guide.run.event.entity.dto.response.get.AllEvent;
+import com.guide.run.event.entity.dto.response.get.AllEventResponse;
+import com.guide.run.event.entity.dto.response.get.UpcomingEventResponse;
+import com.guide.run.event.entity.type.EventRecruitStatus;
+import com.guide.run.event.entity.type.EventType;
+import com.guide.run.user.entity.type.UserType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventResponseContractTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Test
+    @DisplayName("이벤트 목록 응답은 Notion 계약의 필드명과 1-based pagination을 사용한다")
+    void eventListResponseUsesNotionContract() throws Exception {
+        AllEvent item = new AllEvent(
+                101L,
+                EventType.TRAINING,
+                "한강 러닝 모임",
+                LocalDateTime.of(2026, 4, 8, 19, 0),
+                EventRecruitStatus.RECRUIT_END
+        );
+        AllEventResponse response = AllEventResponse.builder()
+                .items(List.of(item))
+                .pagination(AllEventResponse.Pagination.builder()
+                        .page(1)
+                        .size(10)
+                        .totalCount(27)
+                        .totalPages(3)
+                        .hasNext(true)
+                        .build())
+                .build();
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+        assertThat(json.at("/items/0/id").asLong()).isEqualTo(101L);
+        assertThat(json.at("/items/0/type").asText()).isEqualTo("TRAINING");
+        assertThat(json.at("/items/0/dateText").asText()).isEqualTo("2026. 04. 08 수");
+        assertThat(json.at("/items/0/recruitStatus").asText()).isEqualTo("RECRUIT_CLOSE");
+        assertThat(json.at("/items/0/eventId").isMissingNode()).isTrue();
+        assertThat(json.at("/items/0/eventType").isMissingNode()).isTrue();
+        assertThat(json.at("/items/0/startDate").isMissingNode()).isTrue();
+        assertThat(json.at("/pagination/page").asInt()).isEqualTo(1);
+        assertThat(json.at("/pagination/size").asInt()).isEqualTo(10);
+        assertThat(json.at("/pagination/totalCount").asLong()).isEqualTo(27L);
+        assertThat(json.at("/pagination/totalPages").asInt()).isEqualTo(3);
+        assertThat(json.at("/pagination/hasNext").asBoolean()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다가오는 모임 비회원 응답은 viewerType=GUEST와 공개 모임 필드만 사용한다")
+    void upcomingGuestResponseUsesNotionContract() throws Exception {
+        UpcomingEventResponse response = UpcomingEventResponse.guest(List.of(
+                UpcomingEventResponse.GuestItem.builder()
+                        .id(101L)
+                        .name("한강 러닝 모임")
+                        .dDay(3)
+                        .date(LocalDate.of(2026, 5, 14))
+                        .build()
+        ));
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+        assertThat(json.at("/viewerType").asText()).isEqualTo("GUEST");
+        assertThat(json.at("/items/0/id").asLong()).isEqualTo(101L);
+        assertThat(json.at("/items/0/name").asText()).isEqualTo("한강 러닝 모임");
+        assertThat(json.at("/items/0/dDay").asInt()).isEqualTo(3);
+        assertThat(json.at("/items/0/date").asText()).isEqualTo("2026-05-14");
+        assertThat(json.at("/items/0/place").isMissingNode()).isTrue();
+        assertThat(json.at("/items/0/myPartner").isMissingNode()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다가오는 모임 회원 응답은 viewerType=MEMBER와 회원 전용 필드를 사용한다")
+    void upcomingMemberResponseUsesNotionContract() throws Exception {
+        UpcomingEventResponse response = UpcomingEventResponse.member(List.of(
+                UpcomingEventResponse.MemberItem.builder()
+                        .id(101L)
+                        .name("한강 러닝 모임")
+                        .dDay(3)
+                        .place("여의나루역 2번 출구")
+                        .scheduleText("2026년 5월 14일 (목) 오전 10시 ~ 오후 12시")
+                        .myPartner(List.of(
+                                UpcomingEventResponse.PartnerItem.builder()
+                                        .type(UserType.VI)
+                                        .name("홍길동")
+                                        .build()
+                        ))
+                        .build()
+        ));
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+        assertThat(json.at("/viewerType").asText()).isEqualTo("MEMBER");
+        assertThat(json.at("/items/0/id").asLong()).isEqualTo(101L);
+        assertThat(json.at("/items/0/dDay").asInt()).isEqualTo(3);
+        assertThat(json.at("/items/0/place").asText()).isEqualTo("여의나루역 2번 출구");
+        assertThat(json.at("/items/0/scheduleText").asText()).isEqualTo("2026년 5월 14일 (목) 오전 10시 ~ 오후 12시");
+        assertThat(json.at("/items/0/myPartner/0/type").asText()).isEqualTo("VI");
+        assertThat(json.at("/items/0/myPartner/0/name").asText()).isEqualTo("홍길동");
+        assertThat(json.at("/items/0/date").isMissingNode()).isTrue();
+    }
+}

--- a/run/src/test/java/com/guide/run/event/service/EventSearchServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventSearchServiceTest.java
@@ -1,0 +1,46 @@
+package com.guide.run.event.service;
+
+import com.guide.run.event.entity.repository.EventRepository;
+import com.guide.run.event.entity.type.EventRecruitStatus;
+import com.guide.run.event.entity.type.EventType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventSearchServiceTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private EventSearchService eventSearchService;
+
+    @Test
+    @DisplayName("예정 이벤트 검색 카운트는 시작일 필터가 포함된 전용 쿼리를 사용한다")
+    void getSearchAllEventsCountValueUsesUpcomingSearchCountQuery() {
+        when(eventRepository.upcomingGetSearchEventListCount("러닝", null, EventRecruitStatus.RECRUIT_ALL, null))
+                .thenReturn(3L);
+
+        long count = eventSearchService.getSearchAllEventsCountValue(
+                "러닝",
+                "UPCOMING",
+                EventType.TOTAL,
+                EventRecruitStatus.RECRUIT_ALL,
+                null,
+                null
+        );
+
+        assertThat(count).isEqualTo(3L);
+        verify(eventRepository).upcomingGetSearchEventListCount("러닝", null, EventRecruitStatus.RECRUIT_ALL, null);
+        verify(eventRepository, never()).getSearchEventListCount("러닝", null, EventRecruitStatus.RECRUIT_ALL, null);
+    }
+}

--- a/run/src/test/java/com/guide/run/global/exception/ExceptionAdviceOrderTest.java
+++ b/run/src/test/java/com/guide/run/global/exception/ExceptionAdviceOrderTest.java
@@ -1,0 +1,33 @@
+package com.guide.run.global.exception;
+
+import com.guide.run.global.exception.auth.AuthAuthorizeExceptionAdvice;
+import com.guide.run.global.exception.event.EventResourceExceptionAdvice;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.Order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExceptionAdviceOrderTest {
+
+    @Test
+    @DisplayName("인증 예외 advice는 알 수 없는 예외 advice보다 먼저 실행된다")
+    void authAdviceRunsBeforeUnknownAdvice() {
+        assertThat(orderValue(AuthAuthorizeExceptionAdvice.class))
+                .isLessThan(orderValue(UnknownExceptionAdvice.class));
+    }
+
+    @Test
+    @DisplayName("이벤트 리소스 예외 advice는 알 수 없는 예외 advice보다 먼저 실행된다")
+    void eventResourceAdviceRunsBeforeUnknownAdvice() {
+        assertThat(orderValue(EventResourceExceptionAdvice.class))
+                .isLessThan(orderValue(UnknownExceptionAdvice.class));
+    }
+
+    private static int orderValue(Class<?> adviceClass) {
+        Order order = AnnotationUtils.findAnnotation(adviceClass, Order.class);
+        return order == null ? Ordered.LOWEST_PRECEDENCE : order.value();
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 이벤트 목록/검색/다가오는 이벤트 응답을 문서화된 BE 응답 계약 기준으로 정리
- `/api/event/summary`가 전역 CORS 필터를 타도록 security 경로 처리 조정
- 도메인 예외 advice가 공통 예외보다 먼저 적용되도록 우선순위 보강

## 변경 이유
- FE가 임의 보정보다 BE Response 계약에 맞춰 동작하도록 API 응답 구조를 맞춥니다.
- credentials 요청에서 summary API가 CORS 필터를 우회하지 않도록 합니다.
- 이벤트 도메인 예외 응답이 공통 예외로 덮이지 않게 보장합니다.

## 영향 범위
- 이벤트 목록/검색/다가오는 이벤트/summary API 응답
- 이벤트 관련 서비스/레포지토리 DTO 매핑
- 전역 security/CORS 필터 경로
- 예외 처리 advice 우선순위

## 검증
- [x] `APPSMITH_WEBHOOK_SECRET=local-dev-secret ./gradlew test --tests "com.guide.run.event.service.EventResponseContractTest" --tests "com.guide.run.event.service.EventGetServiceTest" --tests "com.guide.run.event.service.EventSearchServiceTest" --tests "com.guide.run.global.exception.ExceptionAdviceOrderTest"`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 다가오는 이벤트 조회에서 사용자 유형(비회원/회원)별 맞춤 정보 제공
  * 페이징 응답에 전체 페이지 수 및 다음 페이지 존재 여부 정보 추가

* **개선 사항**
  * 이벤트 목록 응답 필드명 정규화 (id, type, dateText로 통일)
  * 모집 상태 필터링 로직 개선으로 검색 정확도 향상
  * 페이지 번호 처리 방식 통일 및 최적화
  * 예외 처리 우선순위 설정으로 에러 응답 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->