### PR TITLE
fix: refreshToken 쿠키 기반 reissue 접근 허용

### DIFF
--- a/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
+++ b/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authz) -> authz
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/signup/**").hasRole("NEW")
-                        .requestMatchers("/api/oauth/login/reissue").hasAnyRole("ADMIN", "USER", "COACH", "WAIT", "REJECT")
+                        .requestMatchers("/api/oauth/login/reissue").permitAll()
                         .requestMatchers(
                                 "/api/sms/**",
                                 "/api/oauth/**",

--- a/run/src/test/java/com/guide/run/global/security/config/SecurityConfigAuthTest.java
+++ b/run/src/test/java/com/guide/run/global/security/config/SecurityConfigAuthTest.java
@@ -1,0 +1,74 @@
+package com.guide.run.global.security.config;
+
+import com.guide.run.global.cookie.service.CookieService;
+import com.guide.run.global.jwt.JwtProvider;
+import com.guide.run.global.service.ResponseService;
+import com.guide.run.user.controller.SignController;
+import com.guide.run.user.service.GuideService;
+import com.guide.run.user.service.ProviderService;
+import com.guide.run.user.service.SignupService;
+import com.guide.run.user.service.UserService;
+import com.guide.run.user.service.ViService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SignController.class)
+@Import(SecurityConfig.class)
+@ActiveProfiles("test")
+class SecurityConfigAuthTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private CookieService cookieService;
+
+    @MockBean
+    private ProviderService providerService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private ViService viService;
+
+    @MockBean
+    private GuideService guideService;
+
+    @MockBean
+    private SignupService signupService;
+
+    @MockBean
+    private ResponseService responseService;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    @DisplayName("토큰 재발급 API는 Authorization 헤더 없이 refreshToken 쿠키로 호출할 수 있다")
+    void reissueAllowsRefreshTokenCookieWithoutAuthorizationHeader() throws Exception {
+        when(jwtProvider.getPrivateIdForRefreshToken("refresh-token")).thenReturn("private-id");
+        when(jwtProvider.createAccessToken("private-id")).thenReturn("access-token");
+
+        mockMvc.perform(post("/api/oauth/login/reissue")
+                        .cookie(new Cookie("refreshToken", "refresh-token")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("access-token"));
+    }
+}


### PR DESCRIPTION
## 변경 배경
front-v2 자동로그인에서 `POST /api/oauth/login/reissue` 호출 시 refreshToken 쿠키가 전송되어도 403 Forbidden이 발생했습니다.

## 원인
토큰 재발급 API는 컨트롤러에서 HttpOnly `refreshToken` 쿠키를 검증해 accessToken을 재발급하도록 구현되어 있었지만, Spring Security 설정에서는 해당 endpoint에 accessToken 기반 role 인증을 요구하고 있었습니다. 이 때문에 요청이 컨트롤러의 refreshToken 검증 로직까지 도달하지 못했습니다.

## 주요 변경 사항
- `/api/oauth/login/reissue` security matcher를 `permitAll()`로 변경
- Authorization 헤더 없이 refreshToken 쿠키만으로 reissue API를 호출할 수 있는 회귀 테스트 추가

## 검증
- `./gradlew test --tests "*SecurityConfig*" --tests "*JwtAuthenticationFilterTest"` 통과
- 기존 RED 확인: 회귀 테스트가 수정 전 `expected 200 but was 403`으로 실패함을 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `/api/oauth/login/reissue` 요청이 이제 인증 정보 없이도 처리됩니다.
  * refresh token 쿠키만으로 새 access token을 받을 수 있도록 동작이 변경되었습니다.

* **Tests**
  * 위 재발급 흐름을 검증하는 보안 테스트가 추가되었습니다.
  * Authorization 헤더 없이도 200 OK와 access token 응답을 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->