### PR TITLE
fix: 댓글 createdAt 시분초 반환

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/dto/response/comments/GetComment.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/comments/GetComment.java
@@ -5,15 +5,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Getter
 @Schema(description = "이벤트 댓글 항목")
 public class GetComment {
+    private static final DateTimeFormatter CREATED_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
     @Schema(description = "댓글 ID", example = "301")
     private Long commentId;
     @Schema(description = "댓글 내용", example = "이번 주 토요일에도 참여할게요.")
     private String content;
-    @Schema(description = "작성일", example = "2024-06-15")
+    @Schema(description = "작성일시", example = "2024-06-15T13:45:30")
     private String createdAt;
     @Schema(description = "작성자 사용자 ID", example = "guide_102")
     private String userId;
@@ -24,8 +27,7 @@ public class GetComment {
     public GetComment(Long commentId, String name, String userId, UserType type, String content, LocalDateTime createdAt) {
         this.commentId = commentId;
         this.content = content;
-        this.createdAt = String.format("%d-%02d-%02d",
-                createdAt.getYear(), createdAt.getMonthValue(), createdAt.getDayOfMonth());
+        this.createdAt = createdAt.format(CREATED_AT_FORMATTER);
         this.userId = userId;
         this.name = name;
         this.type = type;

--- a/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
@@ -2,6 +2,7 @@ package com.guide.run.event.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guide.run.event.entity.dto.response.comments.GetComment;
 import com.guide.run.event.entity.dto.response.get.AllEvent;
 import com.guide.run.event.entity.dto.response.get.AllEventResponse;
 import com.guide.run.event.entity.dto.response.get.UpcomingEventResponse;
@@ -110,5 +111,22 @@ class EventResponseContractTest {
         assertThat(json.at("/items/0/myPartner/0/type").asText()).isEqualTo("VI");
         assertThat(json.at("/items/0/myPartner/0/name").asText()).isEqualTo("홍길동");
         assertThat(json.at("/items/0/date").isMissingNode()).isTrue();
+    }
+
+    @Test
+    @DisplayName("댓글 목록 항목의 createdAt은 초 단위까지 포함한 ISO datetime 문자열을 사용한다")
+    void commentCreatedAtIncludesTime() throws Exception {
+        GetComment comment = new GetComment(
+                301L,
+                "홍길동",
+                "guide_102",
+                UserType.GUIDE,
+                "이번 주 토요일에도 참여할게요.",
+                LocalDateTime.of(2026, 6, 24, 13, 45, 30)
+        );
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(comment));
+
+        assertThat(json.at("/createdAt").asText()).isEqualTo("2026-06-24T13:45:30");
     }
 }


### PR DESCRIPTION
## 변경 배경
댓글 목록 응답의 `createdAt`이 `yyyy-MM-dd` 날짜만 내려가 v2 프론트의 상대 시간 계산에서 실제 작성 시간이 반영되지 않았습니다.

## 주요 변경 사항
- `GET /api/event/{eventId}/comments`의 댓글 항목 `createdAt`을 `yyyy-MM-dd'T'HH:mm:ss` 형식으로 반환
- Swagger 예시를 작성일시 기준으로 갱신
- 댓글 응답 계약 테스트 추가

## 검증
- `./gradlew test --tests "com.guide.run.event.service.EventResponseContractTest" --rerun-tasks` 통과
- `git diff --check HEAD` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 댓글 작성일 표시가 날짜만 나오던 형식에서 시간까지 포함한 작성일시로 개선되었습니다.
  * 댓글 응답의 날짜 표기가 더 정확하고 일관된 ISO 형식으로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->