### PR TITLE
fix: 마이페이지 참여 수를 신청 이벤트 기준으로 집계

### DIFF
--- a/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
+++ b/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
@@ -2,6 +2,12 @@ package com.guide.run.user.service;
 
 import com.guide.run.global.exception.user.authorize.UnauthorizedUserException;
 import com.guide.run.global.exception.user.resource.NotExistUserException;
+import com.guide.run.event.entity.Event;
+import com.guide.run.event.entity.EventForm;
+import com.guide.run.event.entity.repository.EventFormRepository;
+import com.guide.run.event.entity.repository.EventRepository;
+import com.guide.run.event.entity.type.EventFormStatus;
+import com.guide.run.event.entity.type.EventType;
 import com.guide.run.user.dto.GuideRunningInfoDto;
 import com.guide.run.user.dto.PermissionDto;
 import com.guide.run.user.dto.PersonalInfoDto;
@@ -22,7 +28,11 @@ import com.guide.run.user.entity.user.Vi;
 import com.guide.run.user.repository.*;
 import com.guide.run.user.repository.user.UserRepository;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,6 +47,8 @@ public class SignupInfoService {
     private final UserRepository userRepository;
     private final ArchiveDataRepository archiveDataRepository;
     private final SignUpInfoRepository signUpInfoRepository;
+    private final EventFormRepository eventFormRepository;
+    private final EventRepository eventRepository;
 
     //약관 동의 조회
     @Transactional
@@ -296,11 +308,7 @@ public class SignupInfoService {
                 .recordDegree(user.getRecordDegree())
                 .build();
 
-        MyPageResponse.Participation participation = MyPageResponse.Participation.builder()
-                .trainingCount(user.getTrainingCnt())
-                .competitionCount(user.getCompetitionCnt())
-                .totalCount(user.getTrainingCnt() + user.getCompetitionCnt())
-                .build();
+        MyPageResponse.Participation participation = getParticipation(privateId);
 
         MyPageResponse.PersonalInfo personalInfo = MyPageResponse.PersonalInfo.builder()
                 .birthDate(user.getBirth())
@@ -322,6 +330,43 @@ public class SignupInfoService {
                 .participation(participation)
                 .personalInfo(personalInfo)
                 .runningInfo(runningInfo)
+                .build();
+    }
+
+    private MyPageResponse.Participation getParticipation(String privateId) {
+        List<Long> eventIds = eventFormRepository.findAllByPrivateId(privateId).stream()
+                .filter(form -> EventFormStatus.APPLIED.equals(form.getStatus()))
+                .map(EventForm::getEventId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        if (eventIds.isEmpty()) {
+            return participation(0, 0);
+        }
+
+        Map<Long, EventType> eventTypesById = eventRepository.findAllById(eventIds).stream()
+                .collect(Collectors.toMap(Event::getId, Event::getType, (first, second) -> first));
+
+        int trainingCount = 0;
+        int competitionCount = 0;
+        for (Long eventId : eventIds) {
+            EventType type = eventTypesById.get(eventId);
+            if (EventType.TRAINING.equals(type)) {
+                trainingCount++;
+            } else if (EventType.COMPETITION.equals(type)) {
+                competitionCount++;
+            }
+        }
+
+        return participation(trainingCount, competitionCount);
+    }
+
+    private MyPageResponse.Participation participation(int trainingCount, int competitionCount) {
+        return MyPageResponse.Participation.builder()
+                .trainingCount(trainingCount)
+                .competitionCount(competitionCount)
+                .totalCount(trainingCount + competitionCount)
                 .build();
     }
 }

--- a/run/src/test/java/com/guide/run/user/service/SignupInfoServiceTest.java
+++ b/run/src/test/java/com/guide/run/user/service/SignupInfoServiceTest.java
@@ -1,6 +1,13 @@
 package com.guide.run.user.service;
 
+import com.guide.run.event.entity.Event;
+import com.guide.run.event.entity.EventForm;
+import com.guide.run.event.entity.repository.EventFormRepository;
+import com.guide.run.event.entity.repository.EventRepository;
+import com.guide.run.event.entity.type.EventFormStatus;
+import com.guide.run.event.entity.type.EventType;
 import com.guide.run.user.dto.request.UpdateRunningInfoRequest;
+import com.guide.run.user.dto.response.MyPageResponse;
 import com.guide.run.user.dto.response.UpdateRunningInfoResponse;
 import com.guide.run.user.entity.ArchiveData;
 import com.guide.run.user.entity.type.UserType;
@@ -14,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +39,8 @@ class SignupInfoServiceTest {
     @Mock private com.guide.run.user.repository.ViRepository viRepository;
     @Mock private com.guide.run.user.repository.GuideRepository guideRepository;
     @Mock private com.guide.run.user.repository.SignUpInfoRepository signUpInfoRepository;
+    @Mock private EventFormRepository eventFormRepository;
+    @Mock private EventRepository eventRepository;
 
     @InjectMocks private SignupInfoService signupInfoService;
 
@@ -76,5 +86,53 @@ class SignupInfoServiceTest {
         assertThat(response.getHopePrefs()).isEqualTo("초보");
         assertThat(archiveData.getRunningPlace()).isEqualTo("한강");
         verify(archiveDataRepository).save(archiveData);
+    }
+
+    @Test
+    @DisplayName("마이페이지 참여 수는 사용자 카운터가 아니라 신청 완료된 이벤트 기준으로 계산한다")
+    void getMyPageCountsParticipationFromAppliedEventForms() {
+        User user = User.builder()
+                .userId("u1")
+                .privateId(PRIVATE_ID)
+                .type(UserType.GUIDE)
+                .trainingCnt(0)
+                .competitionCnt(0)
+                .build();
+        when(userRepository.findById(PRIVATE_ID)).thenReturn(Optional.of(user));
+        when(archiveDataRepository.findById(PRIVATE_ID)).thenReturn(Optional.empty());
+        when(signUpInfoRepository.findById(PRIVATE_ID)).thenReturn(Optional.empty());
+        when(eventFormRepository.findAllByPrivateId(PRIVATE_ID)).thenReturn(List.of(
+                eventForm(1L, EventFormStatus.APPLIED),
+                eventForm(2L, EventFormStatus.APPLIED),
+                eventForm(3L, EventFormStatus.APPLIED),
+                eventForm(4L, EventFormStatus.CANCELED)
+        ));
+        when(eventRepository.findAllById(any())).thenReturn(List.of(
+                event(1L, EventType.TRAINING),
+                event(2L, EventType.TRAINING),
+                event(3L, EventType.COMPETITION),
+                event(4L, EventType.COMPETITION)
+        ));
+
+        MyPageResponse response = signupInfoService.getMyPage(PRIVATE_ID);
+
+        assertThat(response.getParticipation().getTrainingCount()).isEqualTo(2);
+        assertThat(response.getParticipation().getCompetitionCount()).isEqualTo(1);
+        assertThat(response.getParticipation().getTotalCount()).isEqualTo(3);
+    }
+
+    private EventForm eventForm(Long eventId, EventFormStatus status) {
+        return EventForm.builder()
+                .eventId(eventId)
+                .privateId(PRIVATE_ID)
+                .status(status)
+                .build();
+    }
+
+    private Event event(Long eventId, EventType type) {
+        return Event.builder()
+                .id(eventId)
+                .type(type)
+                .build();
     }
 }


### PR DESCRIPTION
## 변경 배경
`/api/user/mypage`의 `participation`이 실제 신청/참여 데이터가 아니라 `user.training_cnt`, `user.competition_cnt` 집계 컬럼을 그대로 반환하고 있어, 해당 컬럼이 갱신되지 않은 사용자에게 0으로 내려가는 문제가 있었습니다.

## 주요 변경 사항
- 마이페이지 참여 수를 `event_form.status = APPLIED`인 이벤트 기준으로 직접 집계하도록 변경
- 이벤트 타입별로 `TRAINING`/`COMPETITION`을 나누어 `trainingCount`, `competitionCount`, `totalCount` 산출
- 사용자 카운터가 0이어도 신청 완료 이벤트 기준으로 참여 수가 반환되는 회귀 테스트 추가

## 검증
- `./gradlew test --tests "com.guide.run.user.service.SignupInfoServiceTest" --rerun-tasks` 성공
- `git diff --check` 성공

## 참고
- 기존 임시 로컬 CORS 변경(`application-local.yml`)은 커밋/PR에 포함하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 마이페이지의 참여 횟수가 사용자 누적값이 아니라, 실제 신청 완료된 이벤트 기준으로 계산되도록 개선되었습니다.
  * 훈련/대회 참여 수와 총 참여 수가 더 정확하게 표시됩니다.

* **Tests**
  * 신청 완료/취소가 섞인 경우에도 참여 수가 올바르게 집계되는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->