### PR TITLE
Fix: 지난 이벤트 종료 시간 기준 필터링

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryCustom.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryCustom.java
@@ -25,8 +25,10 @@ public interface EventRepositoryCustom {
 
     long countEventList(EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     long countUpcomingEventList(EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
+    long countPastEventList(EventType eventType, CityName cityName);
     List<AllEvent> getAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     List<AllEvent> upcomingGetAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
+    List<AllEvent> pastGetAllEventList(int limit, int start, EventType eventType, CityName cityName);
 
     long countByPrivateIdAndCityName(String privateId, CityName cityName);
 
@@ -34,8 +36,10 @@ public interface EventRepositoryCustom {
 
     List<AllEvent> getSearchEventList(int limit, int start, String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     List<AllEvent> upcomingGetSearchEventList(int limit, int start, String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
+    List<AllEvent> pastGetSearchEventList(int limit, int start, String title, EventType eventType, CityName cityName);
     List<AllEvent> getMySearchEventList(int limit, int start, String title, EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId, CityName cityName);
     long upcomingGetSearchEventListCount(String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
+    long pastGetSearchEventListCount(String title, EventType eventType, CityName cityName);
     long getSearchEventListCount(String title, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
     long getMySearchEventListCount(String title, EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId, CityName cityName);
 

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -224,6 +224,20 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
     }
 
     @Override
+    public long countPastEventList(EventType eventType, CityName cityName) {
+        Long result = queryFactory.select(event.count())
+                .from(event)
+                .where(checkByType(eventType)
+                        .and(event.isApprove.eq(true))
+                        .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
+                        .and(checkByPastDateTime())
+                )
+                .fetchOne();
+        return result != null ? result : 0L;
+    }
+
+    @Override
     public List<AllEvent> getAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus,CityName cityName) {
         return queryFactory.select(Projections.constructor(AllEvent.class,
                         event.id.as("eventId"),
@@ -260,6 +274,27 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(checkByUpcomingDate())
                 )
                 .orderBy(event.startTime.asc())
+                .offset(start)
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<AllEvent> pastGetAllEventList(int limit, int start, EventType eventType, CityName cityName) {
+        return queryFactory.select(Projections.constructor(AllEvent.class,
+                        event.id.as("eventId"),
+                        event.type.as("eventType"),
+                        event.name.as("name"),
+                        event.startTime.as("date"),
+                        event.recruitStatus.as("recruitStatus")))
+                .from(event)
+                .where(checkByType(eventType)
+                        .and(event.isApprove.eq(true))
+                        .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
+                        .and(checkByPastDateTime())
+                )
+                .orderBy(event.startTime.desc())
                 .offset(start)
                 .limit(limit)
                 .fetch();
@@ -332,6 +367,28 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
     }
 
     @Override
+    public List<AllEvent> pastGetSearchEventList(int limit, int start, String title, EventType eventType, CityName cityName) {
+        return queryFactory.select(Projections.constructor(AllEvent.class,
+                        event.id.as("eventId"),
+                        event.type.as("eventType"),
+                        event.name.as("name"),
+                        event.startTime.as("date"),
+                        event.recruitStatus.as("recruitStatus")))
+                .from(event)
+                .where(checkByType(eventType)
+                        .and(event.isApprove.eq(true))
+                        .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
+                        .and(checkByTitle(title))
+                        .and(checkByPastDateTime())
+                )
+                .orderBy(event.startTime.desc())
+                .offset(start)
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
     public List<AllEvent> getMySearchEventList(int limit, int start, String title, EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId, CityName cityName) {
         return queryFactory.select(Projections.constructor(AllEvent.class,
                         event.id.as("eventId"),
@@ -365,6 +422,21 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(checkByPublicEvent())
                         .and(checkByTitle(title))
                         .and(checkByUpcomingDate())
+                )
+                .fetchOne();
+        return result != null ? result : 0L;
+    }
+
+    @Override
+    public long pastGetSearchEventListCount(String title, EventType eventType, CityName cityName) {
+        Long result = queryFactory.select(event.count())
+                .from(event)
+                .where(checkByType(eventType)
+                        .and(event.isApprove.eq(true))
+                        .and(checkByCityName(cityName))
+                        .and(checkByPublicEvent())
+                        .and(checkByTitle(title))
+                        .and(checkByPastDateTime())
                 )
                 .fetchOne();
         return result != null ? result : 0L;
@@ -511,6 +583,10 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
 
     private BooleanBuilder checkByUpcomingDate() {
         return new BooleanBuilder(event.startTime.goe(LocalDate.now().atStartOfDay()));
+    }
+
+    private BooleanBuilder checkByPastDateTime() {
+        return new BooleanBuilder(event.endTime.lt(LocalDateTime.now()));
     }
 
     private BooleanBuilder checkByPublicEvent() {

--- a/run/src/main/java/com/guide/run/event/service/EventGetService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventGetService.java
@@ -67,7 +67,7 @@ public class EventGetService {
         if (sort.equals("UPCOMING")) {
             return eventRepository.countUpcomingEventList(type.equals(TOTAL) ? null : type, kind, cityName);
         } else if (sort.equals("END")) {
-            return eventRepository.countEventList(type.equals(TOTAL) ? null : type, RECRUIT_END, cityName);
+            return eventRepository.countPastEventList(type.equals(TOTAL) ? null : type, cityName);
         } else {
             if (type.equals(TOTAL)) {
                 if (kind.equals(RECRUIT_ALL)) {
@@ -117,9 +117,9 @@ public class EventGetService {
             }
         }else if(sort.equals("END")){
             if(type.equals(TOTAL)){
-                allEvents = eventRepository.getAllEventList(limit,start,null, RECRUIT_END,cityName);
+                allEvents = eventRepository.pastGetAllEventList(limit,start,null,cityName);
             }else{
-                allEvents = eventRepository.getAllEventList(limit,start,type,RECRUIT_END,cityName);
+                allEvents = eventRepository.pastGetAllEventList(limit,start,type,cityName);
             }
         }else{
             if(type.equals(TOTAL)){

--- a/run/src/main/java/com/guide/run/event/service/EventSearchService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventSearchService.java
@@ -34,9 +34,9 @@ public class EventSearchService {
             }
         } else if (sort.equals("END")) {
             if (type.equals(TOTAL)) {
-                return eventRepository.getSearchEventListCount(title, null, RECRUIT_END, cityName);
+                return eventRepository.pastGetSearchEventListCount(title, null, cityName);
             } else {
-                return eventRepository.getSearchEventListCount(title, type, RECRUIT_END, cityName);
+                return eventRepository.pastGetSearchEventListCount(title, type, cityName);
             }
         } else {
             if (type.equals(TOTAL)) {
@@ -73,9 +73,9 @@ public class EventSearchService {
             }
         } else if (sort.equals("END")) {
             if (type.equals(TOTAL)) {
-                allEvents = eventRepository.getSearchEventList(limit, start, title, null, RECRUIT_END, cityName);
+                allEvents = eventRepository.pastGetSearchEventList(limit, start, title, null, cityName);
             } else {
-                allEvents = eventRepository.getSearchEventList(limit, start, title, type, RECRUIT_END, cityName);
+                allEvents = eventRepository.pastGetSearchEventList(limit, start, title, type, cityName);
             }
         } else {
             if (type.equals(TOTAL)) {

--- a/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.service;
 
+import com.guide.run.event.entity.dto.response.get.AllEvent;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.EventRecruitStatus;
@@ -10,6 +11,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
@@ -47,9 +51,9 @@ class EventGetServiceTest {
     }
 
     @Test
-    @DisplayName("지난 이벤트 카운트는 공개 이벤트 전용 쿼리를 사용한다")
-    void getAllEventListCountUsesPublicEventCountQueryForEndedEvents() {
-        when(eventRepository.countEventList(null, EventRecruitStatus.RECRUIT_END, null))
+    @DisplayName("지난 이벤트 카운트는 종료 시간 필터가 포함된 전용 쿼리를 사용한다")
+    void getAllEventListCountUsesPastCountQueryForEndedEvents() {
+        when(eventRepository.countPastEventList(null, null))
                 .thenReturn(5L);
 
         long count = eventGetService.getAllEventListCount(
@@ -61,7 +65,38 @@ class EventGetServiceTest {
         );
 
         assertThat(count).isEqualTo(5L);
-        verify(eventRepository).countEventList(null, EventRecruitStatus.RECRUIT_END, null);
-        verify(eventRepository, never()).countByRecruitStatusAndIsApprove(EventRecruitStatus.RECRUIT_END, true);
+        verify(eventRepository).countPastEventList(null, null);
+        verify(eventRepository, never()).countEventList(null, EventRecruitStatus.RECRUIT_END, null);
+    }
+
+    @Test
+    @DisplayName("지난 이벤트 목록은 종료 시간 필터가 포함된 전용 쿼리를 사용한다")
+    void getAllEventListUsesPastListQueryForEndedEvents() {
+        List<AllEvent> pastEvents = List.of(new AllEvent(
+                1L,
+                EventType.TRAINING,
+                "지난 이벤트",
+                LocalDateTime.of(2026, 6, 1, 9, 0),
+                EventRecruitStatus.RECRUIT_OPEN
+        ));
+        when(eventRepository.pastGetAllEventList(10, 0, null, null))
+                .thenReturn(pastEvents);
+        when(eventRepository.countPastEventList(null, null))
+                .thenReturn(1L);
+
+        var response = eventGetService.getAllEventList(
+                10,
+                0,
+                1,
+                "END",
+                EventType.TOTAL,
+                EventRecruitStatus.RECRUIT_ALL,
+                null,
+                null
+        );
+
+        assertThat(response.getItems()).hasSize(1);
+        verify(eventRepository).pastGetAllEventList(10, 0, null, null);
+        verify(eventRepository, never()).getAllEventList(10, 0, null, EventRecruitStatus.RECRUIT_END, null);
     }
 }

--- a/run/src/test/java/com/guide/run/event/service/EventSearchServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventSearchServiceTest.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.service;
 
+import com.guide.run.event.entity.dto.response.get.AllEvent;
 import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
@@ -9,6 +10,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
@@ -42,5 +46,57 @@ class EventSearchServiceTest {
         assertThat(count).isEqualTo(3L);
         verify(eventRepository).upcomingGetSearchEventListCount("러닝", null, EventRecruitStatus.RECRUIT_ALL, null);
         verify(eventRepository, never()).getSearchEventListCount("러닝", null, EventRecruitStatus.RECRUIT_ALL, null);
+    }
+
+    @Test
+    @DisplayName("지난 이벤트 검색 카운트는 종료 시간 필터가 포함된 전용 쿼리를 사용한다")
+    void getSearchAllEventsCountValueUsesPastSearchCountQuery() {
+        when(eventRepository.pastGetSearchEventListCount("러닝", null, null))
+                .thenReturn(4L);
+
+        long count = eventSearchService.getSearchAllEventsCountValue(
+                "러닝",
+                "END",
+                EventType.TOTAL,
+                EventRecruitStatus.RECRUIT_ALL,
+                null,
+                null
+        );
+
+        assertThat(count).isEqualTo(4L);
+        verify(eventRepository).pastGetSearchEventListCount("러닝", null, null);
+        verify(eventRepository, never()).getSearchEventListCount("러닝", null, EventRecruitStatus.RECRUIT_END, null);
+    }
+
+    @Test
+    @DisplayName("지난 이벤트 검색 목록은 종료 시간 필터가 포함된 전용 쿼리를 사용한다")
+    void getSearchAllEventsUsesPastSearchListQuery() {
+        List<AllEvent> pastEvents = List.of(new AllEvent(
+                1L,
+                EventType.TRAINING,
+                "지난 이벤트",
+                LocalDateTime.of(2026, 6, 1, 9, 0),
+                EventRecruitStatus.RECRUIT_OPEN
+        ));
+        when(eventRepository.pastGetSearchEventList(10, 0, "러닝", null, null))
+                .thenReturn(pastEvents);
+        when(eventRepository.pastGetSearchEventListCount("러닝", null, null))
+                .thenReturn(1L);
+
+        var response = eventSearchService.getSearchAllEvents(
+                0,
+                10,
+                1,
+                "러닝",
+                "END",
+                EventType.TOTAL,
+                EventRecruitStatus.RECRUIT_ALL,
+                null,
+                null
+        );
+
+        assertThat(response.getItems()).hasSize(1);
+        verify(eventRepository).pastGetSearchEventList(10, 0, "러닝", null, null);
+        verify(eventRepository, never()).getSearchEventList(10, 0, "러닝", null, EventRecruitStatus.RECRUIT_END, null);
     }
 }


### PR DESCRIPTION
## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
- 전체 이벤트 목록의 지난 이벤트 필터 기준을 `recruitStatus = RECRUIT_END`에서 `endTime < now`로 변경
- 이벤트 검색 목록/카운트도 같은 지난 이벤트 기준을 사용하도록 정리
- 지난 이벤트 목록/검색 조회 기준을 검증하는 서비스 테스트 추가

## **변경 내용**
- 스케줄러 상태 전환이 누락된 이벤트도 종료 시간이 지났다면 지난 이벤트 탭에 노출됩니다.
- 기존 공개/승인/지역/타입 필터는 유지하고, 지난 이벤트 판별 조건만 종료 시간 기준으로 분리했습니다.

## **관련 이슈**
Resolves: 없음

See also: 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 종료된(과거) 이벤트를 별도로 조회하고 검색할 수 있는 기능이 추가되었습니다.
  * 과거 이벤트 목록과 검색 결과에 대한 카운트가 분리되어 더 정확한 페이지네이션이 가능해졌습니다.

* **버그 수정**
  * 종료된 이벤트 조회 시 기존 상태 기준이 아닌 종료 시간 기준으로 일관되게 처리되도록 개선했습니다.
  * 목록과 검색 결과에서 과거 이벤트 전용 조회 경로를 사용하도록 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->