### PR TITLE
Fix: 이벤트 상태를 시간 기준으로 계산

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/dto/response/calender/MyEventOfDayOfCalendar.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/calender/MyEventOfDayOfCalendar.java
@@ -40,9 +40,7 @@ public class MyEventOfDayOfCalendar {
                 recruitStatus,
                 recruitStartDate,
                 recruitEndDate,
-                startDate,
-                EventTemporalStatusResolver.now(),
-                EventTemporalStatusResolver.today()
+                startDate
         );
     }
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/calender/MyEventOfDayOfCalendar.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/calender/MyEventOfDayOfCalendar.java
@@ -1,9 +1,11 @@
 package com.guide.run.event.entity.dto.response.calender;
 
+import com.guide.run.event.service.EventTemporalStatusResolver;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -20,5 +22,27 @@ public class MyEventOfDayOfCalendar {
         this.name = name;
         this.startDate = startDate.getYear()+"."+ startDate.getMonthValue()+"."+ startDate.getDayOfMonth();
         this.recruitStatus = recruitStatus;
+    }
+
+    public MyEventOfDayOfCalendar(long eventId,
+                                  EventType eventType,
+                                  String name,
+                                  LocalDateTime startDate,
+                                  LocalDateTime endDate,
+                                  LocalDate recruitStartDate,
+                                  LocalDate recruitEndDate,
+                                  EventRecruitStatus recruitStatus) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.name = name;
+        this.startDate = startDate.getYear()+"."+ startDate.getMonthValue()+"."+ startDate.getDayOfMonth();
+        this.recruitStatus = EventTemporalStatusResolver.resolveRecruitStatus(
+                recruitStatus,
+                recruitStartDate,
+                recruitEndDate,
+                startDate,
+                EventTemporalStatusResolver.now(),
+                EventTemporalStatusResolver.today()
+        );
     }
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEvent.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEvent.java
@@ -45,9 +45,7 @@ public class AllEvent {
                 recruitStatus,
                 recruitStartDate,
                 recruitEndDate,
-                startDate,
-                EventTemporalStatusResolver.now(),
-                EventTemporalStatusResolver.today()
+                startDate
         );
         this.name = name;
         this.type = eventType;

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEvent.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/AllEvent.java
@@ -1,9 +1,11 @@
 package com.guide.run.event.entity.dto.response.get;
 
+import com.guide.run.event.service.EventTemporalStatusResolver;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.TextStyle;
 import java.util.Locale;
@@ -19,6 +21,34 @@ public class AllEvent {
     public AllEvent(Long eventId, EventType eventType, String name, LocalDateTime startDate, EventRecruitStatus recruitStatus) {
         this.id = eventId;
         this.recruitStatus = toResponseRecruitStatus(recruitStatus);
+        this.name = name;
+        this.type = eventType;
+        this.dateText = String.format(
+                "%04d. %02d. %02d %s",
+                startDate.getYear(),
+                startDate.getMonthValue(),
+                startDate.getDayOfMonth(),
+                startDate.getDayOfWeek().getDisplayName(TextStyle.NARROW, Locale.KOREA)
+        );
+    }
+
+    public AllEvent(Long eventId,
+                    EventType eventType,
+                    String name,
+                    LocalDateTime startDate,
+                    LocalDateTime endDate,
+                    LocalDate recruitStartDate,
+                    LocalDate recruitEndDate,
+                    EventRecruitStatus recruitStatus) {
+        this.id = eventId;
+        this.recruitStatus = EventTemporalStatusResolver.resolveRecruitStatus(
+                recruitStatus,
+                recruitStartDate,
+                recruitEndDate,
+                startDate,
+                EventTemporalStatusResolver.now(),
+                EventTemporalStatusResolver.today()
+        );
         this.name = name;
         this.type = eventType;
         this.dateText = String.format(

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEvent.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEvent.java
@@ -50,9 +50,7 @@ public class MyEvent {
                 recruitStatus,
                 recruitStartDate,
                 recruitEndDate,
-                startDate,
-                EventTemporalStatusResolver.now(),
-                EventTemporalStatusResolver.today()
+                startDate
         );
         this.endDate = endDate.toLocalDate();
     }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEvent.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEvent.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.entity.dto.response.get;
 
+import com.guide.run.event.service.EventTemporalStatusResolver;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,6 +32,28 @@ public class MyEvent {
         this.eventType = eventType;
         this.name = name;
         this.recruitStatus = recruitStatus;
+        this.endDate = endDate.toLocalDate();
+    }
+
+    public MyEvent(Long eventId,
+                   EventType eventType,
+                   String name,
+                   EventRecruitStatus recruitStatus,
+                   LocalDate recruitStartDate,
+                   LocalDate recruitEndDate,
+                   LocalDateTime startDate,
+                   LocalDateTime endDate) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.name = name;
+        this.recruitStatus = EventTemporalStatusResolver.resolveRecruitStatus(
+                recruitStatus,
+                recruitStartDate,
+                recruitEndDate,
+                startDate,
+                EventTemporalStatusResolver.now(),
+                EventTemporalStatusResolver.today()
+        );
         this.endDate = endDate.toLocalDate();
     }
 

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEventDday.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEventDday.java
@@ -17,6 +17,9 @@ public class MyEventDday {
 
     public MyEventDday(String name, LocalDateTime dDay) {
         this.name = name;
-        this.dDay = EventTemporalStatusResolver.now().until(dDay, ChronoUnit.DAYS)+1L;
+        this.dDay = ChronoUnit.DAYS.between(
+                EventTemporalStatusResolver.today(),
+                dDay.toLocalDate()
+        );
     }
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEventDday.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/MyEventDday.java
@@ -1,6 +1,7 @@
 package com.guide.run.event.entity.dto.response.get;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.guide.run.event.service.EventTemporalStatusResolver;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,6 @@ public class MyEventDday {
 
     public MyEventDday(String name, LocalDateTime dDay) {
         this.name = name;
-        this.dDay = LocalDateTime.now().until(dDay, ChronoUnit.DAYS)+1L;
+        this.dDay = EventTemporalStatusResolver.now().until(dDay, ChronoUnit.DAYS)+1L;
     }
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.guide.run.event.entity.dto.response.calender.MyEventOfMonth;
 import com.guide.run.event.entity.dto.response.get.AllEvent;
 import com.guide.run.event.entity.dto.response.get.MyEvent;
 import com.guide.run.event.entity.dto.response.get.MyEventDday;
+import com.guide.run.event.service.EventTemporalStatusResolver;
 import com.guide.run.user.dto.response.MyActivityEventsResponse;
 import com.querydsl.jpa.JPAExpressions;
 import com.guide.run.event.entity.type.CityName;
@@ -44,12 +45,15 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                             event.type.as("eventType"),
                             event.name.as("name"),
                             event.recruitStatus.as("recruitStatus"),
+                            event.recruitStartDate.as("recruitStartDate"),
+                            event.recruitEndDate.as("recruitEndDate"),
+                            event.startTime.as("startDate"),
                             event.endTime.as("endDate"))
                     )
                     .from(event)
                     .join(eventForm).on(event.id.eq(eventForm.eventId),
                             eventForm.privateId.eq(privateId))
-                    .where(event.recruitStatus.eq(eventRecruitStatus)
+                    .where(checkByPastDateTime()
                             .and(event.isApprove.eq(true))
                             .and(event.startTime.year().eq(year))
                             .and(event.id.eq(eventForm.eventId))
@@ -65,12 +69,15 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                                     event.type.as("eventType"),
                                     event.name.as("name"),
                                     event.recruitStatus.as("recruitStatus"),
+                                    event.recruitStartDate.as("recruitStartDate"),
+                                    event.recruitEndDate.as("recruitEndDate"),
+                                    event.startTime.as("startDate"),
                                     event.endTime.as("endDate"))
                     )
                     .from(event)
                     .join(eventForm).on(event.id.eq(eventForm.eventId),
                             eventForm.privateId.eq(privateId))
-                    .where(event.recruitStatus.ne(RECRUIT_END)
+                    .where(checkByUpcomingDate()
                             .and(event.isApprove.eq(true))
                             .and(event.startTime.year().eq(year))
                             .and(event.id.eq(eventForm.eventId))
@@ -80,7 +87,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                     .limit(4)
                     .fetch();
             for(MyEvent myEvent : fetch){
-                myEvent.setdDay((int)DAYS.between(LocalDate.now(),myEvent.getEndDate()));
+                myEvent.setdDay((int)DAYS.between(EventTemporalStatusResolver.today(),myEvent.getEndDate()));
             }
             return fetch;
         }
@@ -111,6 +118,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                                 event.type.as("eventType"),
                                 event.name.as("name"),
                                 event.startTime.as("startDate"),
+                                event.endTime.as("endDate"),
+                                event.recruitStartDate.as("recruitStartDate"),
+                                event.recruitEndDate.as("recruitEndDate"),
                                 event.recruitStatus.as("recruitStatus"))
                 )
                 .from(event)
@@ -146,6 +156,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 event.type.as("eventType"),
                 event.name.as("name"),
                 event.startTime.as("date"),
+                event.endTime.as("endDate"),
+                event.recruitStartDate.as("recruitStartDate"),
+                event.recruitEndDate.as("recruitEndDate"),
                 event.recruitStatus.as("recruitStatus")))
                 .from(event)
                 .join(eventForm).on(eventForm.eventId.eq(event.id))
@@ -244,6 +257,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         event.type.as("eventType"),
                         event.name.as("name"),
                         event.startTime.as("date"),
+                        event.endTime.as("endDate"),
+                        event.recruitStartDate.as("recruitStartDate"),
+                        event.recruitEndDate.as("recruitEndDate"),
                         event.recruitStatus.as("recruitStatus")))
                 .from(event)
                 .where(checkByKind(eventRecruitStatus)
@@ -264,6 +280,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         event.type.as("eventType"),
                         event.name.as("name"),
                         event.startTime.as("date"),
+                        event.endTime.as("endDate"),
+                        event.recruitStartDate.as("recruitStartDate"),
+                        event.recruitEndDate.as("recruitEndDate"),
                         event.recruitStatus.as("recruitStatus")))
                 .from(event)
                 .where(checkByKind(eventRecruitStatus)
@@ -286,6 +305,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         event.type.as("eventType"),
                         event.name.as("name"),
                         event.startTime.as("date"),
+                        event.endTime.as("endDate"),
+                        event.recruitStartDate.as("recruitStartDate"),
+                        event.recruitEndDate.as("recruitEndDate"),
                         event.recruitStatus.as("recruitStatus")))
                 .from(event)
                 .where(checkByType(eventType)
@@ -328,6 +350,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         event.type.as("eventType"),
                         event.name.as("name"),
                         event.startTime.as("date"),
+                        event.endTime.as("endDate"),
+                        event.recruitStartDate.as("recruitStartDate"),
+                        event.recruitEndDate.as("recruitEndDate"),
                         event.recruitStatus.as("recruitStatus")))
                 .from(event)
                 .where(checkByKind(eventRecruitStatus)
@@ -350,6 +375,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         event.type.as("eventType"),
                         event.name.as("name"),
                         event.startTime.as("date"),
+                        event.endTime.as("endDate"),
+                        event.recruitStartDate.as("recruitStartDate"),
+                        event.recruitEndDate.as("recruitEndDate"),
                         event.recruitStatus.as("recruitStatus")))
                 .from(event)
                 .where(checkByKind(eventRecruitStatus)
@@ -373,6 +401,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         event.type.as("eventType"),
                         event.name.as("name"),
                         event.startTime.as("date"),
+                        event.endTime.as("endDate"),
+                        event.recruitStartDate.as("recruitStartDate"),
+                        event.recruitEndDate.as("recruitEndDate"),
                         event.recruitStatus.as("recruitStatus")))
                 .from(event)
                 .where(checkByType(eventType)
@@ -395,6 +426,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         event.type.as("eventType"),
                         event.name.as("name"),
                         event.startTime.as("date"),
+                        event.endTime.as("endDate"),
+                        event.recruitStartDate.as("recruitStartDate"),
+                        event.recruitEndDate.as("recruitEndDate"),
                         event.recruitStatus.as("recruitStatus")))
                 .from(event)
                 .join(eventForm).on(eventForm.eventId.eq(event.id))
@@ -582,11 +616,11 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
     }
 
     private BooleanBuilder checkByUpcomingDate() {
-        return new BooleanBuilder(event.startTime.goe(LocalDate.now().atStartOfDay()));
+        return new BooleanBuilder(event.startTime.gt(EventTemporalStatusResolver.now()));
     }
 
     private BooleanBuilder checkByPastDateTime() {
-        return new BooleanBuilder(event.endTime.lt(LocalDateTime.now()));
+        return new BooleanBuilder(event.endTime.lt(EventTemporalStatusResolver.now()));
     }
 
     private BooleanBuilder checkByPublicEvent() {
@@ -597,15 +631,28 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
         if(kind==null){
             return new BooleanBuilder();
         } else if(kind.equals(RECRUIT_UPCOMING)){
-            return new BooleanBuilder(event.recruitStatus.eq(EventRecruitStatus.RECRUIT_UPCOMING));
+            LocalDate today = EventTemporalStatusResolver.today();
+            LocalDateTime now = EventTemporalStatusResolver.now();
+            return new BooleanBuilder(event.recruitStatus.ne(RECRUIT_CLOSE)
+                    .and(event.startTime.gt(now))
+                    .and(event.recruitStartDate.gt(today)));
         } else if(kind.equals(RECRUIT_OPEN)){
-            return new BooleanBuilder(event.recruitStatus.eq(RECRUIT_OPEN));
+            LocalDate today = EventTemporalStatusResolver.today();
+            LocalDateTime now = EventTemporalStatusResolver.now();
+            return new BooleanBuilder(event.recruitStatus.ne(RECRUIT_CLOSE)
+                    .and(event.startTime.gt(now))
+                    .and(event.recruitStartDate.loe(today))
+                    .and(event.recruitEndDate.goe(today)));
         } else if(kind.equals(RECRUIT_CLOSE)){
-            return new BooleanBuilder(event.recruitStatus.eq(RECRUIT_CLOSE));
+            LocalDate today = EventTemporalStatusResolver.today();
+            LocalDateTime now = EventTemporalStatusResolver.now();
+            return new BooleanBuilder(event.recruitStatus.eq(RECRUIT_CLOSE)
+                    .or(event.startTime.loe(now))
+                    .or(event.recruitEndDate.lt(today)));
         } else if (kind.equals(RECRUIT_END)) {
-            return new BooleanBuilder(event.recruitStatus.eq(RECRUIT_END));
+            return checkByPastDateTime();
         } else if(kind.equals(RECRUIT_ALL)){
-            return new BooleanBuilder(event.recruitStatus.ne(RECRUIT_END));
+            return new BooleanBuilder();
         }
         return null;
     }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -181,7 +181,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .from(event)
                 .join(eventForm).on(event.id.eq(eventForm.eventId),
                         eventForm.privateId.eq(privateId))
-                .where(event.recruitStatus.ne(RECRUIT_END)
+                .where(checkByUpcomingDate()
                         .and(event.isApprove.eq(true))
                         .and(eventForm.eventId.eq(event.id))
                         .and(eventForm.privateId.eq(privateId)))

--- a/run/src/main/java/com/guide/run/event/service/EventFormService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventFormService.java
@@ -60,7 +60,7 @@ public class EventFormService {
     @Transactional
     public Long createForm(EventApplyRequest createForm, Long eventId, String userId) {
         Event event = eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
-        if(!event.getRecruitStatus().equals(RECRUIT_OPEN))
+        if(!EventTemporalStatusResolver.resolveRecruitStatus(event).equals(RECRUIT_OPEN))
             throw new NotValidDurationException();
         User user = userRepository.findUserByPrivateId(userId).orElseThrow(NotExistUserException::new);
         EventForm appliedForm = eventFormRepository.findByEventIdAndPrivateIdAndStatus(
@@ -113,7 +113,7 @@ public class EventFormService {
     @Transactional
     public Long patchForm(EventApplyRequest createForm, Long eventId, String userId) {
         Event event = eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
-        if(!event.getRecruitStatus().equals(RECRUIT_OPEN))
+        if(!EventTemporalStatusResolver.resolveRecruitStatus(event).equals(RECRUIT_OPEN))
             throw new NotValidDurationException();
         userRepository.findUserByPrivateId(userId).orElseThrow(NotExistUserException::new);
         EventForm form = eventFormRepository.findByEventIdAndPrivateIdAndStatus(

--- a/run/src/main/java/com/guide/run/event/service/EventGetService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventGetService.java
@@ -229,13 +229,8 @@ public class EventGetService {
     private boolean isMemberUpcomingEvent(Event event) {
         return event != null
                 && event.isApprove()
-                && event.getRecruitStatus() != RECRUIT_END
                 && event.getStartTime() != null
-                && !event.getStartTime().isBefore(todayStart());
-    }
-
-    private LocalDateTime todayStart() {
-        return LocalDate.now(SERVICE_ZONE).atStartOfDay();
+                && event.getStartTime().isAfter(EventTemporalStatusResolver.now());
     }
 
     private int getDDay(LocalDate date) {

--- a/run/src/main/java/com/guide/run/event/service/EventService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventService.java
@@ -259,7 +259,7 @@ public class EventService {
     public void eventDelete(String userId, Long eventId) {
         Event event = eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
         User user = userRepository.findUserByPrivateId(userId).orElseThrow(NotExistUserException::new);
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = EventTemporalStatusResolver.now();
         if(event.getEndTime().isBefore(now) ||event.getEndTime().isEqual(now)){
             throw new NotDeleteEventException(); //종료된 이벤트는 삭제 못함.
         }
@@ -336,7 +336,7 @@ public class EventService {
                 .organizer(organizerName)
                 .organizerRecord(organizerRecord)
                 .organizerType(organizerType)
-                .recruitStatus(event.getRecruitStatus())
+                .recruitStatus(EventTemporalStatusResolver.resolveRecruitStatus(event))
                 .date(LocalDate.from(event.getStartTime()))
                 .startTime(timeFormatter.getHHMM(event.getStartTime()))
                 .endTime(timeFormatter.getHHMM(event.getEndTime()))
@@ -345,7 +345,7 @@ public class EventService {
                 .viCnt(event.getViCnt())
                 .guideCnt(event.getGuideCnt())
                 .place(event.getPlace())
-                .status(event.getStatus())
+                .status(EventTemporalStatusResolver.resolveEventStatus(event))
                 .content(event.getContent())
                 .updatedAt(LocalDate.from(event.getUpdatedAt()))
                 .isApply(apply)
@@ -423,7 +423,7 @@ public class EventService {
         List<MissingRunningDistanceGetResponse.Item> items = eventRepository
                 .findAllByOrganizerAndEndTimeBeforeAndExpectedRunningDistanceKmIsNullOrderByEndTimeDescIdDesc(
                         privateId,
-                        LocalDateTime.now(),
+                        EventTemporalStatusResolver.now(),
                         PageRequest.of(0, 1)
                 )
                 .stream()
@@ -458,7 +458,8 @@ public class EventService {
         if (!event.getOrganizer().equals(privateId)) {
             throw new NotEventOrganizerException();
         }
-        if (event.getEndTime().isAfter(LocalDateTime.now()) || event.getEndTime().isEqual(LocalDateTime.now())) {
+        LocalDateTime now = EventTemporalStatusResolver.now();
+        if (event.getEndTime().isAfter(now) || event.getEndTime().isEqual(now)) {
             throw new EventValidationException("종료된 이벤트만 러닝 거리를 등록할 수 있습니다.");
         }
 
@@ -485,7 +486,7 @@ public class EventService {
                 .name(event.getName())
                 .eventType(event.getType())
                 .eventCategory(event.getEventCategory())
-                .recruitStatus(event.getRecruitStatus())
+                .recruitStatus(EventTemporalStatusResolver.resolveRecruitStatus(event))
                 .isPrivate(event.isPrivate())
                 .recruitStartDate(event.getRecruitStartDate())
                 .recruitEndDate(event.getRecruitEndDate())

--- a/run/src/main/java/com/guide/run/event/service/EventTemporalStatusResolver.java
+++ b/run/src/main/java/com/guide/run/event/service/EventTemporalStatusResolver.java
@@ -1,0 +1,74 @@
+package com.guide.run.event.service;
+
+import com.guide.run.event.entity.Event;
+import com.guide.run.event.entity.type.EventRecruitStatus;
+import com.guide.run.event.entity.type.EventStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public final class EventTemporalStatusResolver {
+    private static final ZoneId SERVICE_ZONE = ZoneId.of("Asia/Seoul");
+
+    private EventTemporalStatusResolver() {
+    }
+
+    public static LocalDateTime now() {
+        return LocalDateTime.now(SERVICE_ZONE);
+    }
+
+    public static LocalDate today() {
+        return LocalDate.now(SERVICE_ZONE);
+    }
+
+    public static EventRecruitStatus resolveRecruitStatus(Event event) {
+        return resolveRecruitStatus(event, now(), today());
+    }
+
+    public static EventRecruitStatus resolveRecruitStatus(Event event, LocalDateTime now, LocalDate today) {
+        return resolveRecruitStatus(
+                event.getRecruitStatus(),
+                event.getRecruitStartDate(),
+                event.getRecruitEndDate(),
+                event.getStartTime(),
+                now,
+                today
+        );
+    }
+
+    public static EventRecruitStatus resolveRecruitStatus(EventRecruitStatus storedRecruitStatus,
+                                                          LocalDate recruitStartDate,
+                                                          LocalDate recruitEndDate,
+                                                          LocalDateTime startTime,
+                                                          LocalDateTime now,
+                                                          LocalDate today) {
+        if (storedRecruitStatus == EventRecruitStatus.RECRUIT_CLOSE) {
+            return EventRecruitStatus.RECRUIT_CLOSE;
+        }
+        if (startTime != null && !now.isBefore(startTime)) {
+            return EventRecruitStatus.RECRUIT_CLOSE;
+        }
+        if (recruitStartDate != null && today.isBefore(recruitStartDate)) {
+            return EventRecruitStatus.RECRUIT_UPCOMING;
+        }
+        if (recruitEndDate != null && today.isAfter(recruitEndDate)) {
+            return EventRecruitStatus.RECRUIT_CLOSE;
+        }
+        return EventRecruitStatus.RECRUIT_OPEN;
+    }
+
+    public static EventStatus resolveEventStatus(Event event) {
+        return resolveEventStatus(event, now());
+    }
+
+    public static EventStatus resolveEventStatus(Event event, LocalDateTime now) {
+        if (event.getStartTime() != null && now.isBefore(event.getStartTime())) {
+            return EventStatus.EVENT_UPCOMING;
+        }
+        if (event.getEndTime() != null && event.getEndTime().isBefore(now)) {
+            return EventStatus.EVENT_END;
+        }
+        return EventStatus.EVENT_OPEN;
+    }
+}

--- a/run/src/main/java/com/guide/run/event/service/EventTemporalStatusResolver.java
+++ b/run/src/main/java/com/guide/run/event/service/EventTemporalStatusResolver.java
@@ -23,7 +23,8 @@ public final class EventTemporalStatusResolver {
     }
 
     public static EventRecruitStatus resolveRecruitStatus(Event event) {
-        return resolveRecruitStatus(event, now(), today());
+        LocalDateTime now = now();
+        return resolveRecruitStatus(event, now, now.toLocalDate());
     }
 
     public static EventRecruitStatus resolveRecruitStatus(Event event, LocalDateTime now, LocalDate today) {
@@ -34,6 +35,21 @@ public final class EventTemporalStatusResolver {
                 event.getStartTime(),
                 now,
                 today
+        );
+    }
+
+    public static EventRecruitStatus resolveRecruitStatus(EventRecruitStatus storedRecruitStatus,
+                                                          LocalDate recruitStartDate,
+                                                          LocalDate recruitEndDate,
+                                                          LocalDateTime startTime) {
+        LocalDateTime now = now();
+        return resolveRecruitStatus(
+                storedRecruitStatus,
+                recruitStartDate,
+                recruitEndDate,
+                startTime,
+                now,
+                now.toLocalDate()
         );
     }
 
@@ -66,7 +82,7 @@ public final class EventTemporalStatusResolver {
         if (event.getStartTime() != null && now.isBefore(event.getStartTime())) {
             return EventStatus.EVENT_UPCOMING;
         }
-        if (event.getEndTime() != null && event.getEndTime().isBefore(now)) {
+        if (event.getEndTime() != null && !now.isBefore(event.getEndTime())) {
             return EventStatus.EVENT_END;
         }
         return EventStatus.EVENT_OPEN;

--- a/run/src/test/java/com/guide/run/event/service/EventFormRenewalServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventFormRenewalServiceTest.java
@@ -17,6 +17,7 @@ import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import com.guide.run.global.exception.event.authorize.NotEventOrganizerException;
 import com.guide.run.global.exception.event.logic.EventValidationException;
+import com.guide.run.global.exception.event.logic.NotValidDurationException;
 import com.guide.run.partner.entity.matching.UnMatching;
 import com.guide.run.partner.entity.matching.repository.MatchingRepository;
 import com.guide.run.partner.entity.matching.repository.UnMatchingRepository;
@@ -34,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -145,6 +147,64 @@ class EventFormRenewalServiceTest {
         ArgumentCaptor<EventForm> formCaptor = ArgumentCaptor.forClass(EventForm.class);
         verify(eventFormRepository).save(formCaptor.capture());
         assertThat(formCaptor.getValue().getRunningDistanceKm()).isNull();
+        assertThat(formId).isEqualTo(55L);
+        verify(eventAdditionalInfoService).replaceAnswers(1L, 55L, request.getAdditionalAnswers());
+    }
+
+    @Test
+    @DisplayName("신청서 생성은 저장된 상태가 모집중이어도 이벤트 시작 시간이 지났으면 거절한다")
+    void createFormRejectsStaleOpenStatusAfterEventStart() {
+        LocalDate today = EventTemporalStatusResolver.today();
+        LocalDateTime now = EventTemporalStatusResolver.now();
+        Event event = createEvent(
+                EventType.TRAINING,
+                EventRecruitStatus.RECRUIT_OPEN,
+                today.minusDays(2),
+                today.plusDays(2),
+                now.minusMinutes(1),
+                now.plusHours(1)
+        );
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+
+        assertThatThrownBy(() -> eventFormService.createForm(
+                new EventApplyRequest("A", "김가이드", "훈련 참가", null, List.of()),
+                1L,
+                "user-private"
+        )).isInstanceOf(NotValidDurationException.class);
+
+        verify(userRepository, never()).findUserByPrivateId("user-private");
+    }
+
+    @Test
+    @DisplayName("신청서 생성은 저장된 상태가 모집예정이어도 모집 시간이 열려 있으면 허용한다")
+    void createFormAllowsStaleUpcomingStatusDuringRecruitPeriod() {
+        LocalDate today = EventTemporalStatusResolver.today();
+        LocalDateTime now = EventTemporalStatusResolver.now();
+        Event event = createEvent(
+                EventType.TRAINING,
+                EventRecruitStatus.RECRUIT_UPCOMING,
+                today.minusDays(1),
+                today.plusDays(1),
+                now.plusDays(2),
+                now.plusDays(2).plusHours(1)
+        );
+        User user = createUser("user-private", UserType.VI);
+        EventApplyRequest request = new EventApplyRequest("A", "김가이드", "훈련 참가", null, List.of());
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(userRepository.findUserByPrivateId("user-private")).thenReturn(Optional.of(user));
+        when(eventFormRepository.findByEventIdAndPrivateIdAndStatus(1L, "user-private", EventFormStatus.APPLIED))
+                .thenReturn(null);
+        when(eventFormRepository.save(any(EventForm.class))).thenReturn(EventForm.builder()
+                .id(55L)
+                .eventId(1L)
+                .privateId("user-private")
+                .status(EventFormStatus.APPLIED)
+                .build());
+
+        Long formId = eventFormService.createForm(request, 1L, "user-private");
+
         assertThat(formId).isEqualTo(55L);
         verify(eventAdditionalInfoService).replaceAnswers(1L, 55L, request.getAdditionalAnswers());
     }
@@ -460,6 +520,25 @@ class EventFormRenewalServiceTest {
                 .recruitStatus(EventRecruitStatus.RECRUIT_OPEN)
                 .eventCategory(EventCategory.GENERAL)
                 .expectedRunningDistanceKm(expectedRunningDistanceKm)
+                .build();
+    }
+
+    private Event createEvent(EventType eventType,
+                              EventRecruitStatus recruitStatus,
+                              LocalDate recruitStartDate,
+                              LocalDate recruitEndDate,
+                              LocalDateTime startTime,
+                              LocalDateTime endTime) {
+        return Event.builder()
+                .id(1L)
+                .name("상계천천히달리기")
+                .type(eventType)
+                .recruitStatus(recruitStatus)
+                .recruitStartDate(recruitStartDate)
+                .recruitEndDate(recruitEndDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .eventCategory(EventCategory.GENERAL)
                 .build();
     }
 

--- a/run/src/test/java/com/guide/run/event/service/EventFormRenewalServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventFormRenewalServiceTest.java
@@ -266,6 +266,65 @@ class EventFormRenewalServiceTest {
     }
 
     @Test
+    @DisplayName("신청서 수정은 저장된 상태가 모집중이어도 이벤트 시작 시간이 지났으면 거절한다")
+    void patchFormRejectsStaleOpenStatusAfterEventStart() {
+        LocalDate today = EventTemporalStatusResolver.today();
+        LocalDateTime now = EventTemporalStatusResolver.now();
+        Event event = createEvent(
+                EventType.TRAINING,
+                EventRecruitStatus.RECRUIT_OPEN,
+                today.minusDays(2),
+                today.plusDays(2),
+                now.minusMinutes(1),
+                now.plusHours(1)
+        );
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+
+        assertThatThrownBy(() -> eventFormService.patchForm(
+                new EventApplyRequest("A", "김가이드", "훈련 참가", null, List.of()),
+                1L,
+                "user-private"
+        )).isInstanceOf(NotValidDurationException.class);
+
+        verify(userRepository, never()).findUserByPrivateId("user-private");
+    }
+
+    @Test
+    @DisplayName("신청서 수정은 저장된 상태가 모집예정이어도 모집 시간이 열려 있으면 허용한다")
+    void patchFormAllowsStaleUpcomingStatusDuringRecruitPeriod() {
+        LocalDate today = EventTemporalStatusResolver.today();
+        LocalDateTime now = EventTemporalStatusResolver.now();
+        Event event = createEvent(
+                EventType.TRAINING,
+                EventRecruitStatus.RECRUIT_UPCOMING,
+                today.minusDays(1),
+                today.plusDays(1),
+                now.plusDays(2),
+                now.plusDays(2).plusHours(1)
+        );
+        User user = createUser("user-private", UserType.VI);
+        EventForm form = EventForm.builder()
+                .id(55L)
+                .eventId(1L)
+                .privateId("user-private")
+                .status(EventFormStatus.APPLIED)
+                .build();
+        EventApplyRequest request = new EventApplyRequest("A", "김가이드", "훈련 참가", null, List.of());
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(userRepository.findUserByPrivateId("user-private")).thenReturn(Optional.of(user));
+        when(eventFormRepository.findByEventIdAndPrivateIdAndStatus(1L, "user-private", EventFormStatus.APPLIED))
+                .thenReturn(form);
+        when(eventFormRepository.save(form)).thenReturn(form);
+
+        Long formId = eventFormService.patchForm(request, 1L, "user-private");
+
+        assertThat(formId).isEqualTo(55L);
+        verify(eventAdditionalInfoService).replaceAnswers(1L, 55L, request.getAdditionalAnswers());
+    }
+
+    @Test
     @DisplayName("내 신청서 조회는 이벤트, 사용자, 신청 정보와 추가답변을 반환한다")
     void getMyFormReturnsApplicationDetail() {
         Event event = createEvent(EventType.COMPETITION);

--- a/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
@@ -1,10 +1,16 @@
 package com.guide.run.event.service;
 
+import com.guide.run.event.entity.Event;
 import com.guide.run.event.entity.dto.response.get.AllEvent;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
+import com.guide.run.partner.entity.matching.repository.MatchingRepository;
+import com.guide.run.user.entity.type.Role;
+import com.guide.run.user.entity.type.UserType;
+import com.guide.run.user.entity.user.User;
+import com.guide.run.user.repository.user.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,8 +20,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,6 +35,10 @@ class EventGetServiceTest {
     private EventRepository eventRepository;
     @Mock
     private EventFormRepository eventFormRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private MatchingRepository matchingRepository;
 
     @InjectMocks
     private EventGetService eventGetService;
@@ -98,5 +110,67 @@ class EventGetServiceTest {
         assertThat(response.getItems()).hasSize(1);
         verify(eventRepository).pastGetAllEventList(10, 0, null, null);
         verify(eventRepository, never()).getAllEventList(10, 0, null, EventRecruitStatus.RECRUIT_END, null);
+    }
+
+    @Test
+    @DisplayName("회원 다가오는 이벤트는 저장 상태가 이벤트 종료여도 시작 시간이 미래면 반환한다")
+    void getUpcomingEventsIncludesFutureEventWithStaleRecruitEndStatus() {
+        User member = User.builder()
+                .privateId("member-private")
+                .role(Role.ROLE_USER)
+                .type(UserType.GUIDE)
+                .build();
+        Event futureEvent = createEvent(
+                1L,
+                EventRecruitStatus.RECRUIT_END,
+                EventTemporalStatusResolver.now().plusDays(2)
+        );
+
+        when(userRepository.findUserByPrivateId("member-private")).thenReturn(Optional.of(member));
+        when(eventFormRepository.findAllByPrivateId("member-private")).thenReturn(List.of());
+        when(eventRepository.findAllById(any())).thenReturn(List.of());
+        when(eventRepository.findAllByOrganizer("member-private")).thenReturn(List.of(futureEvent));
+
+        var response = eventGetService.getUpcomingEvents("member-private");
+
+        assertThat(response.getItems()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("회원 다가오는 이벤트는 저장 상태가 모집중이어도 이미 시작했으면 제외한다")
+    void getUpcomingEventsExcludesStartedEventWithStaleOpenStatus() {
+        User member = User.builder()
+                .privateId("member-private")
+                .role(Role.ROLE_USER)
+                .type(UserType.GUIDE)
+                .build();
+        Event startedEvent = createEvent(
+                1L,
+                EventRecruitStatus.RECRUIT_OPEN,
+                EventTemporalStatusResolver.now().minusMinutes(1)
+        );
+
+        when(userRepository.findUserByPrivateId("member-private")).thenReturn(Optional.of(member));
+        when(eventFormRepository.findAllByPrivateId("member-private")).thenReturn(List.of());
+        when(eventRepository.findAllById(any())).thenReturn(List.of());
+        when(eventRepository.findAllByOrganizer("member-private")).thenReturn(List.of(startedEvent));
+
+        var response = eventGetService.getUpcomingEvents("member-private");
+
+        assertThat(response.getItems()).isEmpty();
+    }
+
+    private Event createEvent(Long id, EventRecruitStatus recruitStatus, LocalDateTime startTime) {
+        return Event.builder()
+                .id(id)
+                .name("상계천천히달리기")
+                .organizer("member-private")
+                .recruitStatus(recruitStatus)
+                .isApprove(true)
+                .type(EventType.TRAINING)
+                .startTime(startTime)
+                .endTime(startTime.plusHours(2))
+                .place("서울")
+                .build();
     }
 }

--- a/run/src/test/java/com/guide/run/event/service/EventRenewalServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventRenewalServiceTest.java
@@ -396,6 +396,31 @@ class EventRenewalServiceTest {
     }
 
     @Test
+    @DisplayName("이벤트 상세 조회는 저장된 모집 상태 대신 시간 기준 모집 상태를 반환한다")
+    void getDetailEventReturnsComputedRecruitStatus() {
+        LocalDate today = EventTemporalStatusResolver.today();
+        LocalDateTime now = EventTemporalStatusResolver.now();
+        Event event = createEvent(
+                "organizer-private",
+                EventRecruitStatus.RECRUIT_OPEN,
+                EventStatus.EVENT_UPCOMING,
+                today.minusDays(5),
+                today.minusDays(1),
+                now.plusDays(2),
+                now.plusDays(2).plusHours(2)
+        );
+        User organizer = createUser("organizer-private", "organizer-user", "홍길동", UserType.GUIDE);
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(userRepository.findUserByPrivateId("organizer-private")).thenReturn(Optional.of(organizer));
+        when(eventAdditionalInfoService.getQuestions(1L)).thenReturn(List.of());
+
+        EventDetailResponse response = eventService.getDetailEvent(1L, null);
+
+        assertThat(response.getRecruitStatus()).isEqualTo(EventRecruitStatus.RECRUIT_CLOSE);
+    }
+
+    @Test
     @DisplayName("비회원 비공개 이벤트 상세 조회는 거부한다")
     void getDetailEventRejectsPrivateEventForGuest() {
         Event event = createEvent("organizer-private", true);
@@ -459,6 +484,38 @@ class EventRenewalServiceTest {
     }
 
     @Test
+    @DisplayName("이벤트 팝업은 저장된 상태 대신 시간 기준 모집 상태와 이벤트 상태를 반환한다")
+    void eventPopUpReturnsComputedRecruitAndEventStatus() {
+        User viewer = createUser("viewer-private", "viewer-user", "김철수", UserType.GUIDE);
+        User organizer = createUser("organizer-private", "organizer-user", "홍길동", UserType.GUIDE);
+        LocalDate today = EventTemporalStatusResolver.today();
+        LocalDateTime now = EventTemporalStatusResolver.now();
+        Event event = createEvent(
+                "organizer-private",
+                EventRecruitStatus.RECRUIT_OPEN,
+                EventStatus.EVENT_UPCOMING,
+                today.minusDays(5),
+                today.plusDays(5),
+                now.minusHours(3),
+                now.minusHours(1)
+        );
+        ReflectionTestUtils.setField(event, "updatedAt", now);
+
+        when(userRepository.findUserByPrivateId("viewer-private")).thenReturn(Optional.of(viewer));
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(userRepository.findUserByPrivateId("organizer-private")).thenReturn(Optional.of(organizer));
+        when(timeFormatter.getHHMM(event.getStartTime())).thenReturn("09:00");
+        when(timeFormatter.getHHMM(event.getEndTime())).thenReturn("11:00");
+        when(eventFormRepository.findByEventIdAndPrivateIdAndStatus(1L, "viewer-private", EventFormStatus.APPLIED))
+                .thenReturn(null);
+
+        EventPopUpResponse response = eventService.eventPopUp(1L, "viewer-private");
+
+        assertThat(response.getRecruitStatus()).isEqualTo(EventRecruitStatus.RECRUIT_CLOSE);
+        assertThat(response.getStatus()).isEqualTo(EventStatus.EVENT_END);
+    }
+
+    @Test
     @DisplayName("이벤트 상세 응답 boolean 필드는 is 접두사 JSON 키를 유지한다")
     void eventDetailResponseSerializesBooleanKeysWithIsPrefix() throws Exception {
         EventDetailResponse response = EventDetailResponse.builder()
@@ -502,6 +559,35 @@ class EventRenewalServiceTest {
                 .place("서울")
                 .content("내용")
                 .status(EventStatus.EVENT_UPCOMING)
+                .eventCategory(EventCategory.GENERAL)
+                .expectedRunningDistanceKm(new BigDecimal("7.50"))
+                .build();
+    }
+
+    private Event createEvent(String organizer,
+                              EventRecruitStatus recruitStatus,
+                              EventStatus status,
+                              LocalDate recruitStartDate,
+                              LocalDate recruitEndDate,
+                              LocalDateTime startTime,
+                              LocalDateTime endTime) {
+        return Event.builder()
+                .id(1L)
+                .organizer(organizer)
+                .recruitStartDate(recruitStartDate)
+                .recruitEndDate(recruitEndDate)
+                .name("상계천천히달리기")
+                .recruitStatus(recruitStatus)
+                .isPrivate(false)
+                .isApprove(true)
+                .type(EventType.TRAINING)
+                .startTime(startTime)
+                .endTime(endTime)
+                .maxNumV(4)
+                .maxNumG(4)
+                .place("서울")
+                .content("내용")
+                .status(status)
                 .eventCategory(EventCategory.GENERAL)
                 .expectedRunningDistanceKm(new BigDecimal("7.50"))
                 .build();

--- a/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
@@ -60,6 +60,26 @@ class EventResponseContractTest {
     }
 
     @Test
+    @DisplayName("이벤트 목록 항목은 projection의 시간 필드로 현재 모집 상태를 계산한다")
+    void allEventComputesRecruitStatusFromTemporalFields() {
+        LocalDate today = EventTemporalStatusResolver.today();
+        LocalDateTime now = EventTemporalStatusResolver.now();
+
+        AllEvent item = new AllEvent(
+                101L,
+                EventType.TRAINING,
+                "한강 러닝 모임",
+                now.plusDays(3),
+                now.plusDays(3).plusHours(2),
+                today.minusDays(5),
+                today.minusDays(1),
+                EventRecruitStatus.RECRUIT_OPEN
+        );
+
+        assertThat(item.getRecruitStatus()).isEqualTo(EventRecruitStatus.RECRUIT_CLOSE);
+    }
+
+    @Test
     @DisplayName("다가오는 모임 비회원 응답은 viewerType=GUEST와 공개 모임 필드만 사용한다")
     void upcomingGuestResponseUsesNotionContract() throws Exception {
         UpcomingEventResponse response = UpcomingEventResponse.guest(List.of(

--- a/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guide.run.event.entity.dto.response.comments.GetComment;
 import com.guide.run.event.entity.dto.response.get.AllEvent;
 import com.guide.run.event.entity.dto.response.get.AllEventResponse;
+import com.guide.run.event.entity.dto.response.get.MyEventDday;
 import com.guide.run.event.entity.dto.response.get.UpcomingEventResponse;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
@@ -77,6 +78,16 @@ class EventResponseContractTest {
         );
 
         assertThat(item.getRecruitStatus()).isEqualTo(EventRecruitStatus.RECRUIT_CLOSE);
+    }
+
+    @Test
+    @DisplayName("나의 이벤트 D-day 항목은 날짜 기준으로 남은 일수를 계산한다")
+    void myEventDdayUsesDateBasedDayCount() {
+        LocalDateTime eventDate = EventTemporalStatusResolver.now().plusDays(2);
+
+        MyEventDday item = new MyEventDday("한강 러닝 모임", eventDate);
+
+        assertThat(item.getDDay()).isEqualTo(2L);
     }
 
     @Test

--- a/run/src/test/java/com/guide/run/event/service/EventTemporalStatusResolverTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventTemporalStatusResolverTest.java
@@ -1,0 +1,140 @@
+package com.guide.run.event.service;
+
+import com.guide.run.event.entity.Event;
+import com.guide.run.event.entity.type.EventRecruitStatus;
+import com.guide.run.event.entity.type.EventStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventTemporalStatusResolverTest {
+
+    private final LocalDate today = LocalDate.of(2026, 6, 28);
+    private final LocalDateTime now = LocalDateTime.of(2026, 6, 28, 12, 0);
+
+    @Test
+    @DisplayName("모집 시작 전이면 저장된 상태와 무관하게 모집 예정으로 계산한다")
+    void resolveRecruitStatusReturnsUpcomingBeforeRecruitStartDate() {
+        Event event = createEvent(
+                EventRecruitStatus.RECRUIT_OPEN,
+                today.plusDays(1),
+                today.plusDays(3),
+                now.plusDays(5),
+                now.plusDays(5).plusHours(2)
+        );
+
+        EventRecruitStatus status = EventTemporalStatusResolver.resolveRecruitStatus(event, now, today);
+
+        assertThat(status).isEqualTo(EventRecruitStatus.RECRUIT_UPCOMING);
+    }
+
+    @Test
+    @DisplayName("모집 기간 중이고 이벤트 시작 전이면 모집중으로 계산한다")
+    void resolveRecruitStatusReturnsOpenDuringRecruitPeriodBeforeEventStart() {
+        Event event = createEvent(
+                EventRecruitStatus.RECRUIT_UPCOMING,
+                today.minusDays(1),
+                today.plusDays(1),
+                now.plusDays(2),
+                now.plusDays(2).plusHours(2)
+        );
+
+        EventRecruitStatus status = EventTemporalStatusResolver.resolveRecruitStatus(event, now, today);
+
+        assertThat(status).isEqualTo(EventRecruitStatus.RECRUIT_OPEN);
+    }
+
+    @Test
+    @DisplayName("모집 종료일이 지나면 저장된 상태와 무관하게 모집 마감으로 계산한다")
+    void resolveRecruitStatusReturnsCloseAfterRecruitEndDate() {
+        Event event = createEvent(
+                EventRecruitStatus.RECRUIT_OPEN,
+                today.minusDays(5),
+                today.minusDays(1),
+                now.plusDays(2),
+                now.plusDays(2).plusHours(2)
+        );
+
+        EventRecruitStatus status = EventTemporalStatusResolver.resolveRecruitStatus(event, now, today);
+
+        assertThat(status).isEqualTo(EventRecruitStatus.RECRUIT_CLOSE);
+    }
+
+    @Test
+    @DisplayName("이벤트가 시작됐으면 모집 종료일이 남아 있어도 모집 마감으로 계산한다")
+    void resolveRecruitStatusReturnsCloseAfterEventStart() {
+        Event event = createEvent(
+                EventRecruitStatus.RECRUIT_OPEN,
+                today.minusDays(1),
+                today.plusDays(1),
+                now.minusMinutes(1),
+                now.plusHours(2)
+        );
+
+        EventRecruitStatus status = EventTemporalStatusResolver.resolveRecruitStatus(event, now, today);
+
+        assertThat(status).isEqualTo(EventRecruitStatus.RECRUIT_CLOSE);
+    }
+
+    @Test
+    @DisplayName("저장된 모집 상태가 조기 마감이면 시간이 남아 있어도 모집 마감으로 유지한다")
+    void resolveRecruitStatusKeepsManualClose() {
+        Event event = createEvent(
+                EventRecruitStatus.RECRUIT_CLOSE,
+                today.minusDays(1),
+                today.plusDays(1),
+                now.plusDays(2),
+                now.plusDays(2).plusHours(2)
+        );
+
+        EventRecruitStatus status = EventTemporalStatusResolver.resolveRecruitStatus(event, now, today);
+
+        assertThat(status).isEqualTo(EventRecruitStatus.RECRUIT_CLOSE);
+    }
+
+    @Test
+    @DisplayName("이벤트 시간 기준으로 예정, 진행중, 종료 상태를 계산한다")
+    void resolveEventStatusByEventTime() {
+        assertThat(EventTemporalStatusResolver.resolveEventStatus(createEvent(
+                EventRecruitStatus.RECRUIT_OPEN,
+                today,
+                today,
+                now.plusMinutes(1),
+                now.plusHours(1)
+        ), now)).isEqualTo(EventStatus.EVENT_UPCOMING);
+
+        assertThat(EventTemporalStatusResolver.resolveEventStatus(createEvent(
+                EventRecruitStatus.RECRUIT_OPEN,
+                today,
+                today,
+                now.minusMinutes(1),
+                now.plusHours(1)
+        ), now)).isEqualTo(EventStatus.EVENT_OPEN);
+
+        assertThat(EventTemporalStatusResolver.resolveEventStatus(createEvent(
+                EventRecruitStatus.RECRUIT_OPEN,
+                today,
+                today,
+                now.minusHours(2),
+                now.minusMinutes(1)
+        ), now)).isEqualTo(EventStatus.EVENT_END);
+    }
+
+    private Event createEvent(EventRecruitStatus recruitStatus,
+                              LocalDate recruitStartDate,
+                              LocalDate recruitEndDate,
+                              LocalDateTime startTime,
+                              LocalDateTime endTime) {
+        return Event.builder()
+                .recruitStatus(recruitStatus)
+                .recruitStartDate(recruitStartDate)
+                .recruitEndDate(recruitEndDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .build();
+    }
+}

--- a/run/src/test/java/com/guide/run/event/service/EventTemporalStatusResolverTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventTemporalStatusResolverTest.java
@@ -124,6 +124,35 @@ class EventTemporalStatusResolverTest {
         ), now)).isEqualTo(EventStatus.EVENT_END);
     }
 
+    @Test
+    @DisplayName("이벤트 종료 시각 정각이면 종료 상태로 계산한다")
+    void resolveEventStatusReturnsEndAtExactEndTime() {
+        Event event = createEvent(
+                EventRecruitStatus.RECRUIT_OPEN,
+                today,
+                today,
+                now.minusHours(2),
+                now
+        );
+
+        EventStatus status = EventTemporalStatusResolver.resolveEventStatus(event, now);
+
+        assertThat(status).isEqualTo(EventStatus.EVENT_END);
+    }
+
+    @Test
+    @DisplayName("모집 상태 raw 필드 계산은 같은 현재 시각에서 날짜를 파생한다")
+    void resolveRecruitStatusWithRawFieldsDerivesTodayFromSameNow() {
+        EventRecruitStatus status = EventTemporalStatusResolver.resolveRecruitStatus(
+                EventRecruitStatus.RECRUIT_UPCOMING,
+                today.minusDays(1),
+                today.plusDays(1),
+                now.plusDays(2)
+        );
+
+        assertThat(status).isEqualTo(EventRecruitStatus.RECRUIT_OPEN);
+    }
+
     private Event createEvent(EventRecruitStatus recruitStatus,
                               LocalDate recruitStartDate,
                               LocalDate recruitEndDate,


### PR DESCRIPTION
## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
- 이벤트 모집/진행 상태를 DB 상태값 대신 저장된 시간 기준으로 계산하는 공통 로직 추가
- 이벤트 신청/수정 API에서 계산된 모집 상태로 신청 가능 여부 판단
- 이벤트 상세/팝업 API에서 계산된 모집 상태와 이벤트 상태 반환
- 이벤트 목록/검색/다가오는/내 이벤트/캘린더 상세 조회의 필터와 응답 상태를 시간 기준으로 정리

## **변경 내용**
- 스케줄러가 상태값을 갱신하지 못해도 사용자 핵심 API는 `recruitStartDate`, `recruitEndDate`, `startTime`, `endTime` 기준으로 현재 상태를 계산합니다.
- 조기 마감으로 저장된 `RECRUIT_CLOSE`는 유지하고, 사용자 응답의 모집 종료 상태는 `RECRUIT_CLOSE`로 정규화합니다.
- 기존 스케줄러와 DB 상태 저장 구조는 변경하지 않았습니다.
- 검증: `./gradlew test --tests "*Event*" --rerun-tasks`, `git diff --check develop...HEAD`

## **관련 이슈**
Resolves: 없음

See also: 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 이벤트와 모집 상태를 현재 시각 기준으로 자동 계산해 보여주도록 응답이 개선되었습니다.
  * 달력, 목록, 상세, 팝업 등 여러 화면에서 더 일관된 상태 값이 표시됩니다.

* **Bug Fixes**
  * 시간 경과 후에도 잘못된 모집 상태가 노출되던 문제를 개선했습니다.
  * 다가오는 이벤트와 종료 이벤트 판정이 실제 시작/종료 시각 기준으로 더 정확해졌습니다.

* **Tests**
  * 시간 경계 조건과 상태 계산을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->