### PR TITLE
fix: ROLE_WAIT 마이페이지 접근 허용

### DIFF
--- a/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
+++ b/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
@@ -86,6 +86,7 @@ public class SecurityConfig {
                         .requestMatchers(new RegexRequestMatcher("^/api/event/[0-9]+/comments(\\?.*)?$", "GET")).permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers(
+                                "/api/user/mypage",
                                 "/api/user/personal/**",
                                 "/api/user/permission/**",
                                 "/api/user/running/**",

--- a/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
+++ b/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
@@ -1,0 +1,72 @@
+package com.guide.run.global.security.config;
+
+import com.guide.run.global.jwt.JwtProvider;
+import com.guide.run.global.service.ResponseService;
+import com.guide.run.user.controller.SignupInfoController;
+import com.guide.run.user.dto.response.MyPageResponse;
+import com.guide.run.user.service.SignupInfoService;
+import com.guide.run.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SignupInfoController.class)
+@Import(SecurityConfig.class)
+@ActiveProfiles("test")
+class SecurityConfigMypageAuthTest {
+
+    private static final String WAIT_TOKEN = "wait-token";
+    private static final String PRIVATE_ID = "private-id";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private SignupInfoService signupInfoService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private ResponseService responseService;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    @DisplayName("ROLE_WAIT 회원은 마이페이지를 조회할 수 있다")
+    void waitUserCanAccessMypage() throws Exception {
+        when(jwtProvider.validateTokenExpiration(WAIT_TOKEN)).thenReturn(true);
+        when(jwtProvider.getAuthentication(WAIT_TOKEN)).thenReturn(new UsernamePasswordAuthenticationToken(
+                PRIVATE_ID,
+                "",
+                List.of(new SimpleGrantedAuthority("ROLE_WAIT"))
+        ));
+        when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
+        when(signupInfoService.getMyPage(PRIVATE_ID)).thenReturn(MyPageResponse.builder().build());
+
+        mockMvc.perform(get("/api/user/mypage")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 변경 배경
`/api/user/mypage`가 `ROLE_WAIT`/`ROLE_REJECT` 허용 matcher에 포함되지 않아 대기 회원이 fallback `/api/**` 인가 규칙에서 403을 받는 문제가 있었습니다.

## 주요 변경 사항
- `/api/user/mypage`를 `ROLE_WAIT`/`ROLE_REJECT`도 접근 가능한 사용자 정보 API 목록에 추가
- `ROLE_WAIT` 회원의 마이페이지 접근을 검증하는 WebMvc 보안 테스트 추가

## 검증
- `./gradlew test --tests "com.guide.run.global.security.config.*" --rerun-tasks` 성공
- `git diff --check` 성공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `/api/user/mypage` 접근 권한이 기존 사용자 권한 범위에 포함되어, 승인 대기 사용자도 마이페이지에 정상 접근할 수 있게 되었습니다.
* **Tests**
  * 마이페이지 접근 권한이 올바르게 동작하는지 확인하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->