### PR TITLE
fix: ROLE_WAIT 계정 등록 API 접근 허용

### DIFF
--- a/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
+++ b/run/src/main/java/com/guide/run/global/security/config/SecurityConfig.java
@@ -86,6 +86,8 @@ public class SecurityConfig {
                         .requestMatchers(new RegexRequestMatcher("^/api/event/[0-9]+/comments(\\?.*)?$", "GET")).permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers(
+                                "/api/user/account",
+                                "/api/user/account/duplicated",
                                 "/api/user/mypage",
                                 "/api/user/personal/**",
                                 "/api/user/permission/**",

--- a/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
+++ b/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
@@ -4,6 +4,9 @@ import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.global.service.ResponseService;
 import com.guide.run.user.controller.SignupInfoController;
 import com.guide.run.user.dto.response.MyPageResponse;
+import com.guide.run.user.dto.response.SetAccountResponse;
+import com.guide.run.user.dto.response.UpdatePersonalInfoResponse;
+import com.guide.run.user.dto.response.UpdateRunningInfoResponse;
 import com.guide.run.user.service.SignupInfoService;
 import com.guide.run.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,6 +18,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
@@ -25,6 +29,8 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = SignupInfoController.class)
@@ -56,17 +62,101 @@ class SecurityConfigMypageAuthTest {
     @Test
     @DisplayName("ROLE_WAIT 회원은 마이페이지를 조회할 수 있다")
     void waitUserCanAccessMypage() throws Exception {
-        when(jwtProvider.validateTokenExpiration(WAIT_TOKEN)).thenReturn(true);
-        when(jwtProvider.getAuthentication(WAIT_TOKEN)).thenReturn(new UsernamePasswordAuthenticationToken(
-                PRIVATE_ID,
-                "",
-                List.of(new SimpleGrantedAuthority("ROLE_WAIT"))
-        ));
+        authenticateWaitUser();
         when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
         when(signupInfoService.getMyPage(PRIVATE_ID)).thenReturn(MyPageResponse.builder().build());
 
         mockMvc.perform(get("/api/user/mypage")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("ROLE_WAIT 회원은 계정 아이디 중복 확인을 할 수 있다")
+    void waitUserCanCheckAccountDuplicated() throws Exception {
+        authenticateWaitUser();
+        when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
+        when(userService.isAccountIdExist("runner01")).thenReturn(false);
+
+        mockMvc.perform(post("/api/user/account/duplicated")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "accountId": "runner01"
+                                }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("ROLE_WAIT 회원은 아이디와 비밀번호를 최초 등록할 수 있다")
+    void waitUserCanSetAccount() throws Exception {
+        authenticateWaitUser();
+        when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
+        when(userService.setAccount(any(), any(), any())).thenReturn(SetAccountResponse.builder()
+                .accountId("runner01")
+                .build());
+
+        mockMvc.perform(post("/api/user/account")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "accountId": "runner01",
+                                  "password": "Pass1234!"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("ROLE_WAIT 회원은 개인정보를 수정할 수 있다")
+    void waitUserCanUpdatePersonalInfo() throws Exception {
+        authenticateWaitUser();
+        when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
+        when(signupInfoService.updatePersonalInfo(any(), any())).thenReturn(UpdatePersonalInfoResponse.builder().build());
+
+        mockMvc.perform(patch("/api/user/personal")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "birthDate": "1995-03-15",
+                                  "phoneNumber": "01012345678",
+                                  "snsId": "@runner",
+                                  "id1365": "runner1365"
+                                }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("ROLE_WAIT 회원은 러닝 정보를 수정할 수 있다")
+    void waitUserCanUpdateRunningInfo() throws Exception {
+        authenticateWaitUser();
+        when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
+        when(signupInfoService.updateRunningInfo(any(), any())).thenReturn(UpdateRunningInfoResponse.builder().build());
+
+        mockMvc.perform(patch("/api/user/running")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "recordDegree": "A",
+                                  "detailRecord": "10km 55분",
+                                  "hopePrefs": "서울 한강"
+                                }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    private void authenticateWaitUser() {
+        when(jwtProvider.validateTokenExpiration(WAIT_TOKEN)).thenReturn(true);
+        when(jwtProvider.getAuthentication(WAIT_TOKEN)).thenReturn(new UsernamePasswordAuthenticationToken(
+                PRIVATE_ID,
+                "",
+                List.of(new SimpleGrantedAuthority("ROLE_WAIT"))
+        ));
     }
 }


### PR DESCRIPTION
## 변경 배경
`ROLE_WAIT` 회원이 마이페이지에서 아이디/비밀번호 최초 등록을 진행해야 하지만, `POST /api/user/account`와 `POST /api/user/account/duplicated`가 WAIT 허용 matcher에 없어 fallback `/api/**` 인가 규칙에서 403을 받았습니다.

## 주요 변경 사항
- `POST /api/user/account`를 `ROLE_WAIT`/`ROLE_REJECT` 접근 가능 사용자 API 목록에 추가
- `POST /api/user/account/duplicated`도 같은 목록에 추가
- 기존 마이페이지 보안 테스트에 다음 ROLE_WAIT 접근 케이스 추가
  - 계정 아이디 중복 확인
  - 아이디/비밀번호 최초 등록
  - 개인정보 수정
  - 러닝 정보 수정

## 확인 결과
- `PATCH /api/user/personal`은 기존 matcher로 `ROLE_WAIT` 접근 가능함을 테스트로 확인
- `PATCH /api/user/running`도 기존 matcher로 `ROLE_WAIT` 접근 가능함을 테스트로 확인

## 검증
- `./gradlew test --tests "com.guide.run.global.security.config.*" --tests "com.guide.run.user.service.SignupInfoServiceTest" --rerun-tasks` 성공
- `git diff --check HEAD~1 HEAD` 성공

## 참고
- `UserServiceTest`까지 넓혀 실행했을 때는 로컬 test profile의 `${TEST_RDS}`가 실제 JDBC URL로 치환되지 않아 기존 Spring context 테스트가 실패했습니다. 이번 변경과 직접 관련된 보안/SignupInfo 테스트는 통과했습니다.