### PR TITLE
chore: 로컬 전용 작업 문서를 docs-local/로 통합하고 gitignore 정리

### DIFF
--- a/run/.gitignore
+++ b/run/.gitignore
@@ -43,22 +43,16 @@ out/
 ## Environment files
 .env
 
-## DB info (sensitive)
-db_info.txt
-db_schema_issues.txt
-
-## Internal work documents
-미구현_API_목록.md
+## 로컬 전용 작업 문서 (DB 접속정보/토큰 등 민감정보 포함, 버전관리 제외)
+##  - db_info.txt, db_schema_issues.txt : DB 접속정보 및 스키마 이슈
+##  - 미구현_API_목록.md                : API 명세 대비 미구현 정리
+##  - 스케줄러_분석.txt                 : 스케줄러 구조 분석
+##  - 통합테스트결과/                   : 통합테스트 결과 (토큰 포함)
+docs-local/
 
 ## API test files (local only, contains tokens)
 http-tests/
 
-## 에러 확인 안내 문서 (로컬 전용)
-에러_확인_방법.txt
-
 ## 애플리케이션 로그 (런타임 생성물)
 logs/
-
-## 통합테스트 결과 (로컬 전용, 토큰 포함)
-통합테스트결과/
 boot.log


### PR DESCRIPTION
## 변경 내용

흩어져 있던 로컬 전용 작업 문서들을 `docs-local/` 한 폴더로 통합하고, `.gitignore`를 폴더 하나만 무시하도록 정리했습니다.

### `.gitignore` 정리
- 6개로 흩어져 있던 문서 무시 규칙(`db_info.txt`, `db_schema_issues.txt`, `미구현_API_목록.md`, `통합테스트결과/` 등)을 `docs-local/` 단일 규칙으로 통합
- 실제 존재하지 않던 항목(`에러_확인_방법.txt`) 제거

### 역할 구분
- `docs/` — 버전관리에 포함되는 공유 문서
- `docs-local/` — DB 접속정보·토큰 등 민감정보 포함 로컬 전용 문서 (자동 제외)

> 문서 파일 자체는 원래 gitignore 대상이라 이번 PR의 실제 diff는 `.gitignore` 한 파일입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 로컬 전용 문서와 테스트 산출물, 로그 제외 규칙을 정리했습니다.
  * 개별 파일을 여러 개 나열하던 방식에서, 로컬 문서 디렉터리 단위로 더 간단하게 관리하도록 변경했습니다.
  * 로컬 토큰이 포함될 수 있는 API 테스트 파일과 런타임 로그는 계속 제외되도록 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->