### PR TITLE
Fix: 이벤트 재신청 상태 기준 정리

### DIFF
--- a/run/src/main/java/com/guide/run/event/service/EventFormService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventFormService.java
@@ -42,6 +42,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.guide.run.event.entity.type.EventRecruitStatus.RECRUIT_OPEN;
 
@@ -233,8 +235,13 @@ public class EventFormService {
     public EventCanceledApplicantListResponse getCanceledApplicantForms(Long eventId) {
         eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
         List<EventForm> canceledForms = eventFormRepository.findAllByEventIdAndStatus(eventId, EventFormStatus.CANCELED);
+        Set<String> activePrivateIds = eventFormRepository.findAllByEventIdAndStatus(eventId, EventFormStatus.APPLIED)
+                .stream()
+                .map(EventForm::getPrivateId)
+                .collect(Collectors.toSet());
 
         List<EventCanceledApplicantListResponse.CanceledApplicant> applicants = canceledForms.stream()
+                .filter(form -> !activePrivateIds.contains(form.getPrivateId()))
                 .map(form -> {
                     User user = userRepository.findUserByPrivateId(form.getPrivateId()).orElse(null);
                     if (user == null) return null;

--- a/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
@@ -8,7 +8,9 @@ import com.guide.run.event.entity.dto.request.match.MatchingCreateRequest;
 import com.guide.run.event.entity.dto.response.match.*;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
+import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.global.exception.event.resource.NotExistEventException;
+import com.guide.run.global.exception.event.resource.NotExistFormException;
 import com.guide.run.global.exception.user.resource.NotExistUserException;
 import com.guide.run.partner.entity.matching.Matching;
 import com.guide.run.partner.entity.matching.UnMatching;
@@ -65,8 +67,19 @@ public class EventMatchingService {
         eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
         User vi = userRepository.findUserByUserId(viId).orElseThrow(NotExistUserException::new);
         User guide = userRepository.findUserByUserId(userId).orElseThrow(NotExistUserException::new);
-        EventForm viForm = eventFormRepository.findByEventIdAndPrivateId(eventId, vi.getPrivateId());
-        EventForm guideForm = eventFormRepository.findByEventIdAndPrivateId(eventId, guide.getPrivateId());
+        EventForm viForm = eventFormRepository.findByEventIdAndPrivateIdAndStatus(
+                eventId,
+                vi.getPrivateId(),
+                EventFormStatus.APPLIED
+        );
+        EventForm guideForm = eventFormRepository.findByEventIdAndPrivateIdAndStatus(
+                eventId,
+                guide.getPrivateId(),
+                EventFormStatus.APPLIED
+        );
+        if (viForm == null || guideForm == null) {
+            throw new NotExistFormException("해당 이벤트에 대한 신청 폼이 존재하지 않습니다.");
+        }
         Matching existGuide = matchingRepository.findByEventIdAndGuideId(eventId, guide.getPrivateId());
         if(existGuide!=null){
             //existGuide의 파트너 삭제 추가
@@ -340,7 +353,11 @@ public class EventMatchingService {
             for (Matching m : matchings) {
                 User guide = userRepository.findUserByPrivateId(m.getGuideId()).orElse(null);
                 if (guide == null) continue;
-                EventForm form = eventFormRepository.findByEventIdAndPrivateId(eventId, guide.getPrivateId());
+                EventForm form = eventFormRepository.findByEventIdAndPrivateIdAndStatus(
+                        eventId,
+                        guide.getPrivateId(),
+                        EventFormStatus.APPLIED
+                );
                 partners.add(MatchingStatusUser.builder()
                         .userId(guide.getUserId())
                         .name(guide.getName())
@@ -353,7 +370,11 @@ public class EventMatchingService {
             if (matching != null) {
                 User vi = userRepository.findUserByPrivateId(matching.getViId()).orElse(null);
                 if (vi != null) {
-                    EventForm form = eventFormRepository.findByEventIdAndPrivateId(eventId, vi.getPrivateId());
+                    EventForm form = eventFormRepository.findByEventIdAndPrivateIdAndStatus(
+                            eventId,
+                            vi.getPrivateId(),
+                            EventFormStatus.APPLIED
+                    );
                     partners.add(MatchingStatusUser.builder()
                             .userId(vi.getUserId())
                             .name(vi.getName())

--- a/run/src/main/java/com/guide/run/partner/entity/matching/repository/MatchingRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/partner/entity/matching/repository/MatchingRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.guide.run.event.entity.QEventForm;
 import com.guide.run.event.entity.dto.response.match.MatchedGuideInfo;
 import com.guide.run.event.entity.dto.response.match.MatchedViInfo;
 import com.guide.run.event.entity.dto.response.match.MatchingCompletedFlatDto;
+import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.entity.user.QUser;
 import com.querydsl.core.types.Projections;
@@ -38,7 +39,9 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                 .from(matching)
                 .where(matching.eventId.eq(eventId).and(matching.viId.eq(viId)))
                 .join(user).on(user.privateId.eq(matching.guideId))
-                .join(eventForm).on(user.privateId.eq(eventForm.privateId).and(eventForm.eventId.eq(eventId)))
+                .join(eventForm).on(user.privateId.eq(eventForm.privateId)
+                        .and(eventForm.eventId.eq(eventId))
+                        .and(eventForm.status.eq(EventFormStatus.APPLIED)))
                 .join(attendance).on(user.privateId.eq(attendance.privateId).and(attendance.eventId.eq(eventId)))
                 .orderBy(user.name.asc())
                 .fetch();
@@ -55,7 +58,9 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                         user.recordDegree.as("recordDegree")))
                 .from(matching)
                 .join(user).on(user.privateId.eq(matching.viId))
-                .join(eventForm).on(user.privateId.eq(eventForm.privateId).and(eventForm.eventId.eq(eventId)))
+                .join(eventForm).on(user.privateId.eq(eventForm.privateId)
+                        .and(eventForm.eventId.eq(eventId))
+                        .and(eventForm.status.eq(EventFormStatus.APPLIED)))
                 .join(attendance).on(user.privateId.eq(attendance.privateId).and(attendance.eventId.eq(eventId)))
                 .where(matching.eventId.eq(eventId).and(user.type.eq(userType)))
                 .orderBy(user.name.asc())
@@ -88,10 +93,14 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                         guideUser.recordDegree.as("guideRecordDegree")))
                 .from(matching)
                 .join(viUser).on(viUser.privateId.eq(matching.viId))
-                .join(viForm).on(viForm.privateId.eq(matching.viId).and(viForm.eventId.eq(eventId)))
+                .join(viForm).on(viForm.privateId.eq(matching.viId)
+                        .and(viForm.eventId.eq(eventId))
+                        .and(viForm.status.eq(EventFormStatus.APPLIED)))
                 .join(viAttendance).on(viAttendance.privateId.eq(matching.viId).and(viAttendance.eventId.eq(eventId)))
                 .join(guideUser).on(guideUser.privateId.eq(matching.guideId))
-                .join(guideForm).on(guideForm.privateId.eq(matching.guideId).and(guideForm.eventId.eq(eventId)))
+                .join(guideForm).on(guideForm.privateId.eq(matching.guideId)
+                        .and(guideForm.eventId.eq(eventId))
+                        .and(guideForm.status.eq(EventFormStatus.APPLIED)))
                 .join(guideAttendance).on(guideAttendance.privateId.eq(matching.guideId).and(guideAttendance.eventId.eq(eventId)))
                 .where(matching.eventId.eq(eventId))
                 .orderBy(viForm.hopeTeam.asc(), viUser.name.asc(), guideUser.name.asc())

--- a/run/src/main/java/com/guide/run/partner/entity/matching/repository/UnMatchingRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/partner/entity/matching/repository/UnMatchingRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.guide.run.partner.entity.matching.repository;
 
 import com.guide.run.event.entity.dto.response.match.MatchingWaitingFlatDto;
 import com.guide.run.event.entity.dto.response.match.NotMatchUserInfo;
+import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.user.entity.type.UserType;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -41,7 +42,9 @@ public class UnMatchingRepositoryImpl implements UnMatchingRepositoryCustom
                 user.recordDegree.as("recordDegree")))
                 .from(unMatching)
                 .join(user).on(unMatching.privateId.eq(user.privateId))
-                .join(eventForm).on(unMatching.privateId.eq(eventForm.privateId).and(eventForm.eventId.eq(eventId)))
+                .join(eventForm).on(unMatching.privateId.eq(eventForm.privateId)
+                        .and(eventForm.eventId.eq(eventId))
+                        .and(eventForm.status.eq(EventFormStatus.APPLIED)))
                 .join(attendance).on(unMatching.privateId.eq(attendance.privateId).and(attendance.eventId.eq(eventId)))
                 .where(unMatching.eventId.eq(eventId))
                 .orderBy(user.name.asc())
@@ -61,7 +64,9 @@ public class UnMatchingRepositoryImpl implements UnMatchingRepositoryCustom
                         user.competitionCnt.as("competitionCnt")))
                 .from(unMatching)
                 .join(user).on(unMatching.privateId.eq(user.privateId))
-                .join(eventForm).on(unMatching.privateId.eq(eventForm.privateId).and(eventForm.eventId.eq(eventId)))
+                .join(eventForm).on(unMatching.privateId.eq(eventForm.privateId)
+                        .and(eventForm.eventId.eq(eventId))
+                        .and(eventForm.status.eq(EventFormStatus.APPLIED)))
                 .where(unMatching.eventId.eq(eventId))
                 .orderBy(eventForm.hopeTeam.asc(), user.name.asc())
                 .fetch();

--- a/run/src/test/java/com/guide/run/event/service/EventFormRenewalServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventFormRenewalServiceTest.java
@@ -7,6 +7,7 @@ import com.guide.run.event.entity.EventForm;
 import com.guide.run.event.entity.dto.request.EventApplyRequest;
 import com.guide.run.event.entity.dto.response.form.EventApplicantFormResponse;
 import com.guide.run.event.entity.dto.response.form.EventApplicantListResponse;
+import com.guide.run.event.entity.dto.response.form.EventCanceledApplicantListResponse;
 import com.guide.run.event.entity.dto.response.form.MyEventApplyGetResponse;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
@@ -465,6 +466,61 @@ class EventFormRenewalServiceTest {
                 .containsExactly("vi-user", "guide-user");
         assertThat(group.getApplicants().get(0).isFirstParticipation()).isTrue();
         assertThat(group.getApplicants().get(1).isFirstParticipation()).isFalse();
+    }
+
+    @Test
+    @DisplayName("취소자 명단은 재신청해서 APPLIED 상태인 참가자를 제외한다")
+    void getCanceledApplicantFormsExcludesReappliedUsers() {
+        Event event = createEvent(EventType.TRAINING);
+        EventForm canceledOnlyForm = EventForm.builder()
+                .id(55L)
+                .privateId("canceled-only-private")
+                .eventId(1L)
+                .status(EventFormStatus.CANCELED)
+                .canceledAt(LocalDateTime.of(2026, 1, 1, 10, 0))
+                .build();
+        EventForm reappliedCanceledForm = EventForm.builder()
+                .id(56L)
+                .privateId("reapplied-private")
+                .eventId(1L)
+                .status(EventFormStatus.CANCELED)
+                .canceledAt(LocalDateTime.of(2026, 1, 1, 11, 0))
+                .build();
+        EventForm reappliedActiveForm = EventForm.builder()
+                .id(57L)
+                .privateId("reapplied-private")
+                .eventId(1L)
+                .status(EventFormStatus.APPLIED)
+                .build();
+        User canceledOnlyUser = User.builder()
+                .privateId("canceled-only-private")
+                .userId("canceled-only-user")
+                .name("취소만한 사용자")
+                .type(UserType.VI)
+                .build();
+        User reappliedUser = User.builder()
+                .privateId("reapplied-private")
+                .userId("reapplied-user")
+                .name("재신청 사용자")
+                .type(UserType.GUIDE)
+                .build();
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(eventFormRepository.findAllByEventIdAndStatus(1L, EventFormStatus.CANCELED))
+                .thenReturn(List.of(canceledOnlyForm, reappliedCanceledForm));
+        lenient().when(eventFormRepository.findAllByEventIdAndStatus(1L, EventFormStatus.APPLIED))
+                .thenReturn(List.of(reappliedActiveForm));
+        when(userRepository.findUserByPrivateId("canceled-only-private")).thenReturn(Optional.of(canceledOnlyUser));
+        lenient().when(userRepository.findUserByPrivateId("reapplied-private")).thenReturn(Optional.of(reappliedUser));
+
+        EventCanceledApplicantListResponse response = eventFormService.getCanceledApplicantForms(1L);
+
+        assertThat(response.getSummary().getTotalCount()).isEqualTo(1);
+        assertThat(response.getSummary().getViCount()).isEqualTo(1);
+        assertThat(response.getSummary().getGuideCount()).isZero();
+        assertThat(response.getCanceledApplicants())
+                .extracting(EventCanceledApplicantListResponse.CanceledApplicant::getUserId)
+                .containsExactly("canceled-only-user");
     }
 
     @Test

--- a/run/src/test/java/com/guide/run/event/service/EventMatchingQueryFilterTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventMatchingQueryFilterTest.java
@@ -1,0 +1,34 @@
+package com.guide.run.event.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventMatchingQueryFilterTest {
+
+    @Test
+    @DisplayName("매칭 대기 조회 QueryDSL은 APPLIED 신청서만 조인한다")
+    void matchingWaitingQueryFiltersAppliedEventForms() throws IOException {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/guide/run/partner/entity/matching/repository/UnMatchingRepositoryImpl.java"
+        ));
+
+        assertThat(source).contains("eventForm.status.eq(EventFormStatus.APPLIED)");
+    }
+
+    @Test
+    @DisplayName("매칭 완료 조회 QueryDSL은 APPLIED 신청서만 조인한다")
+    void matchingCompletedQueryFiltersAppliedEventForms() throws IOException {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/guide/run/partner/entity/matching/repository/MatchingRepositoryImpl.java"
+        ));
+
+        assertThat(source).contains("viForm.status.eq(EventFormStatus.APPLIED)");
+        assertThat(source).contains("guideForm.status.eq(EventFormStatus.APPLIED)");
+    }
+}

--- a/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
@@ -1,0 +1,114 @@
+package com.guide.run.event.service;
+
+import com.guide.run.attendance.repository.AttendanceRepository;
+import com.guide.run.event.entity.Event;
+import com.guide.run.event.entity.EventForm;
+import com.guide.run.event.entity.repository.EventFormRepository;
+import com.guide.run.event.entity.repository.EventRepository;
+import com.guide.run.event.entity.type.EventFormStatus;
+import com.guide.run.partner.entity.matching.Matching;
+import com.guide.run.partner.entity.matching.repository.MatchingRepository;
+import com.guide.run.partner.entity.matching.repository.UnMatchingRepository;
+import com.guide.run.partner.service.PartnerService;
+import com.guide.run.user.entity.type.UserType;
+import com.guide.run.user.entity.user.User;
+import com.guide.run.user.repository.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventMatchingServiceTest {
+    @Mock
+    private UnMatchingRepository unMatchingRepository;
+    @Mock
+    private MatchingRepository matchingRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private EventFormRepository eventFormRepository;
+    @Mock
+    private PartnerService partnerService;
+    @Mock
+    private AttendanceRepository attendanceRepository;
+
+    @InjectMocks
+    private EventMatchingService eventMatchingService;
+
+    @Test
+    @DisplayName("수동 매칭은 취소 이력이 있어도 APPLIED 신청서를 기준으로 생성한다")
+    void matchUserUsesAppliedFormsWhenCanceledHistoryExists() {
+        User vi = User.builder()
+                .privateId("vi-private")
+                .userId("vi-user")
+                .type(UserType.VI)
+                .build();
+        User guide = User.builder()
+                .privateId("guide-private")
+                .userId("guide-user")
+                .type(UserType.GUIDE)
+                .build();
+        EventForm canceledViForm = EventForm.builder()
+                .eventId(1L)
+                .privateId("vi-private")
+                .hopeTeam("VI-CANCELED")
+                .status(EventFormStatus.CANCELED)
+                .build();
+        EventForm canceledGuideForm = EventForm.builder()
+                .eventId(1L)
+                .privateId("guide-private")
+                .hopeTeam("GUIDE-CANCELED")
+                .status(EventFormStatus.CANCELED)
+                .build();
+        EventForm appliedViForm = EventForm.builder()
+                .eventId(1L)
+                .privateId("vi-private")
+                .hopeTeam("VI-APPLIED")
+                .status(EventFormStatus.APPLIED)
+                .build();
+        EventForm appliedGuideForm = EventForm.builder()
+                .eventId(1L)
+                .privateId("guide-private")
+                .hopeTeam("GUIDE-APPLIED")
+                .status(EventFormStatus.APPLIED)
+                .build();
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(Event.builder().id(1L).build()));
+        when(userRepository.findUserByUserId("vi-user")).thenReturn(Optional.of(vi));
+        when(userRepository.findUserByUserId("guide-user")).thenReturn(Optional.of(guide));
+        lenient().when(eventFormRepository.findByEventIdAndPrivateId(1L, "vi-private"))
+                .thenReturn(canceledViForm);
+        lenient().when(eventFormRepository.findByEventIdAndPrivateId(1L, "guide-private"))
+                .thenReturn(canceledGuideForm);
+        lenient().when(eventFormRepository.findByEventIdAndPrivateIdAndStatus(1L, "vi-private", EventFormStatus.APPLIED))
+                .thenReturn(appliedViForm);
+        lenient().when(eventFormRepository.findByEventIdAndPrivateIdAndStatus(1L, "guide-private", EventFormStatus.APPLIED))
+                .thenReturn(appliedGuideForm);
+        when(matchingRepository.findByEventIdAndGuideId(1L, "guide-private")).thenReturn(null);
+        when(unMatchingRepository.findByPrivateIdAndEventId("vi-private", 1L)).thenReturn(Optional.empty());
+
+        eventMatchingService.matchUser(1L, "vi-user", "guide-user");
+
+        ArgumentCaptor<Matching> matchingCaptor = ArgumentCaptor.forClass(Matching.class);
+        verify(matchingRepository).save(matchingCaptor.capture());
+        Matching savedMatching = matchingCaptor.getValue();
+        assertThat(savedMatching.getViRecord()).isEqualTo("VI-APPLIED");
+        assertThat(savedMatching.getGuideRecord()).isEqualTo("GUIDE-APPLIED");
+        verify(eventFormRepository).findByEventIdAndPrivateIdAndStatus(1L, "vi-private", EventFormStatus.APPLIED);
+        verify(eventFormRepository).findByEventIdAndPrivateIdAndStatus(1L, "guide-private", EventFormStatus.APPLIED);
+    }
+}


### PR DESCRIPTION
## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
- 이벤트 취소 후 재신청한 사용자의 매칭 조회/생성 기준을 `APPLIED` 신청서로 제한
- 취소자 명단에서 현재 다시 신청한 사용자를 제외
- 취소 이력과 활성 신청서가 함께 존재하는 케이스에 대한 회귀 테스트 추가

## **변경 내용**
- 매칭 대기/완료 조회 QueryDSL 조인에 `EventFormStatus.APPLIED` 조건 추가
- 수동 매칭 생성 시 `CANCELED` 이력이 아닌 활성 신청서만 조회하도록 변경
- 취소자 명단 생성 시 같은 이벤트에 `APPLIED` 신청서가 있는 사용자는 필터링

## **관련 이슈**
Resolves: 없음

See also: 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 취소자 명단에서 이미 다시 신청한 사용자가 중복 포함되지 않도록 개선했습니다.
  * 매칭/비매칭 결과가 현재 **신청 완료(APPLIED)** 상태 기준으로만 집계되도록 정리했습니다.
  * 매칭 생성 시 취소 이력이 있더라도 현재 신청 상태가 유효하면 정상 처리되도록 수정했습니다.

* **Tests**
  * 위 변경사항을 검증하는 자동화 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->