### PR TITLE
fix: 신청자 명단 정렬 적용

### DIFF
--- a/run/src/main/java/com/guide/run/event/service/EventFormService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventFormService.java
@@ -38,8 +38,10 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -49,6 +51,14 @@ import static com.guide.run.event.entity.type.EventRecruitStatus.RECRUIT_OPEN;
 @Service
 @RequiredArgsConstructor
 public class EventFormService {
+    private static final Comparator<String> TEXT_ORDER = Comparator.nullsLast(String::compareTo);
+    private static final Comparator<Map.Entry<String, List<EventForm>>> GROUP_ORDER = Comparator
+            .comparingInt((Map.Entry<String, List<EventForm>> entry) -> runningGroupOrder(entry.getKey()))
+            .thenComparing(Map.Entry::getKey, TEXT_ORDER);
+    private static final Comparator<EventApplicantListResponse.EventApplicant> APPLICANT_ORDER = Comparator
+            .comparingInt((EventApplicantListResponse.EventApplicant applicant) -> userTypeOrder(applicant.getType()))
+            .thenComparing(EventApplicantListResponse.EventApplicant::getName, TEXT_ORDER);
+
     private final EventFormRepository eventFormRepository;
     private final UserRepository userRepository;
     private final EventRepository eventRepository;
@@ -177,11 +187,13 @@ public class EventFormService {
         }
 
         List<EventApplicantListResponse.EventApplicantGroup> groups = groupedForms.entrySet().stream()
+                .sorted(GROUP_ORDER)
                 .map(entry -> EventApplicantListResponse.EventApplicantGroup.builder()
                         .runningGroup(entry.getKey())
                         .totalCount(entry.getValue().size())
                         .applicants(entry.getValue().stream()
                                 .map(this::toApplicant)
+                                .sorted(APPLICANT_ORDER)
                                 .toList())
                         .build())
                 .toList();
@@ -384,6 +396,33 @@ public class EventFormService {
                 .type(user.getType())
                 .isFirstParticipation(user.getTrainingCnt() + user.getCompetitionCnt() == 0)
                 .build();
+    }
+
+    private static int runningGroupOrder(String runningGroup) {
+        if (runningGroup == null) {
+            return Integer.MAX_VALUE;
+        }
+
+        String normalized = runningGroup.trim().toUpperCase(Locale.ROOT);
+        if (normalized.isEmpty()) {
+            return Integer.MAX_VALUE;
+        }
+
+        char group = normalized.charAt(0);
+        if (group >= 'A' && group <= 'E') {
+            return group - 'A';
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    private static int userTypeOrder(UserType type) {
+        if (type == UserType.VI) {
+            return 0;
+        }
+        if (type == UserType.GUIDE) {
+            return 1;
+        }
+        return 2;
     }
 
     private List<EventApplicantFormResponse.AdditionalAnswer> toApplicantAdditionalAnswers(Long formId) {

--- a/run/src/test/java/com/guide/run/event/service/EventFormRenewalServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventFormRenewalServiceTest.java
@@ -468,6 +468,41 @@ class EventFormRenewalServiceTest {
     }
 
     @Test
+    @DisplayName("신청자 명단은 러닝그룹 A-E 순서와 그룹 내 VI, Guide 이름순으로 정렬한다")
+    void getApplicantFormsSortsGroupsAndApplicants() {
+        EventForm guideB = applicantForm("guide-b-private", UserType.GUIDE, "B");
+        EventForm viC = applicantForm("vi-c-private", UserType.VI, "C");
+        EventForm guideAHa = applicantForm("guide-a-ha-private", UserType.GUIDE, "A");
+        EventForm viANa = applicantForm("vi-a-na-private", UserType.VI, "A");
+        EventForm guideAGa = applicantForm("guide-a-ga-private", UserType.GUIDE, "A");
+        EventForm viAGa = applicantForm("vi-a-ga-private", UserType.VI, "A");
+
+        when(eventFormRepository.findAllByEventIdAndStatus(1L, EventFormStatus.APPLIED))
+                .thenReturn(List.of(guideB, viC, guideAHa, viANa, guideAGa, viAGa));
+        when(userRepository.findUserByPrivateId("guide-b-private"))
+                .thenReturn(Optional.of(applicantUser("guide-b", "나가이드", UserType.GUIDE)));
+        when(userRepository.findUserByPrivateId("vi-c-private"))
+                .thenReturn(Optional.of(applicantUser("vi-c", "다비", UserType.VI)));
+        when(userRepository.findUserByPrivateId("guide-a-ha-private"))
+                .thenReturn(Optional.of(applicantUser("guide-a-ha", "하가이드", UserType.GUIDE)));
+        when(userRepository.findUserByPrivateId("vi-a-na-private"))
+                .thenReturn(Optional.of(applicantUser("vi-a-na", "나비", UserType.VI)));
+        when(userRepository.findUserByPrivateId("guide-a-ga-private"))
+                .thenReturn(Optional.of(applicantUser("guide-a-ga", "가가이드", UserType.GUIDE)));
+        when(userRepository.findUserByPrivateId("vi-a-ga-private"))
+                .thenReturn(Optional.of(applicantUser("vi-a-ga", "가비", UserType.VI)));
+
+        EventApplicantListResponse response = eventFormService.getApplicantForms(1L);
+
+        assertThat(response.getGroups())
+                .extracting(EventApplicantListResponse.EventApplicantGroup::getRunningGroup)
+                .containsExactly("A", "B", "C");
+        assertThat(response.getGroups().get(0).getApplicants())
+                .extracting(EventApplicantListResponse.EventApplicant::getUserId)
+                .containsExactly("vi-a-ga", "vi-a-na", "guide-a-ga", "guide-a-ha");
+    }
+
+    @Test
     @DisplayName("신청자 신청서 상세는 이벤트 주최자가 조회할 수 있다")
     void getApplicantFormAllowsOrganizer() {
         Event event = Event.builder()
@@ -607,6 +642,27 @@ class EventFormRenewalServiceTest {
                 .type(type)
                 .age(30)
                 .gender("M")
+                .build();
+    }
+
+    private EventForm applicantForm(String privateId, UserType type, String hopeTeam) {
+        return EventForm.builder()
+                .privateId(privateId)
+                .eventId(1L)
+                .type(type)
+                .hopeTeam(hopeTeam)
+                .status(EventFormStatus.APPLIED)
+                .build();
+    }
+
+    private User applicantUser(String userId, String name, UserType type) {
+        return User.builder()
+                .privateId(userId + "-private")
+                .userId(userId)
+                .name(name)
+                .type(type)
+                .trainingCnt(1)
+                .competitionCnt(0)
                 .build();
     }
 


### PR DESCRIPTION
## 변경 배경
`GET /api/event/{eventId}/forms` 응답에서 그룹 및 신청자 배열 순서가 repository 반환 순서에 의존하고 있어, 프론트/운영 화면에서 일관된 정렬을 보장하지 못했습니다.

## 주요 변경 사항
- `groups`를 러닝그룹 A-E 순서로 정렬
- 각 그룹의 `applicants`를 VI 먼저, GUIDE 다음 순서로 정렬
- 같은 타입 안에서는 신청자 이름 오름차순으로 정렬
- 정렬 계약을 검증하는 서비스 테스트 추가

## 검증
- `./gradlew test --tests "com.guide.run.event.service.EventFormRenewalServiceTest" --rerun-tasks` 성공
- GitHub compare 기준 변경 파일: `EventFormService.java`, `EventFormRenewalServiceTest.java`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 신청자 목록이 그룹 순서와 신청자 정렬 기준에 맞게 표시되도록 개선했습니다.
  * 빈 값이나 대소문자 차이도 일관되게 처리해 정렬 결과를 더 안정적으로 만들었습니다.

* **Tests**
  * 신청자 목록 정렬이 기대한 순서대로 반환되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->