### PR TITLE
fix: 매칭 현황에 미매칭 VI 포함

### DIFF
--- a/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
@@ -309,12 +309,25 @@ public class EventMatchingService {
             rowMap.get(flat.getViUserId()).getGuides().add(guide);
         }
 
-        // 3. 미매칭 Guide → guide의 hopeTeam 기준 vi=null 행으로 추가
+        // 3. 미매칭 참가자 → VI는 독립 행, Guide는 vi=null 행으로 추가
         List<MatchingWaitingFlatDto> waitingFlat = unMatchingRepository.findWaitingParticipants(eventId);
         for (MatchingWaitingFlatDto flat : waitingFlat) {
-            if (flat.getType() != UserType.GUIDE) continue;
             String rg = flat.getHopeTeam() != null ? flat.getHopeTeam() : "";
             groupRowMap.computeIfAbsent(rg, k -> new LinkedHashMap<>());
+            if (flat.getType() == UserType.VI) {
+                MatchingStatusUser viUser = MatchingStatusUser.builder()
+                        .userId(flat.getUserId())
+                        .name(flat.getName())
+                        .type(flat.getType())
+                        .applyGroup(flat.getHopeTeam())
+                        .build();
+                groupRowMap.get(rg).put("unmatched_vi_" + flat.getUserId(), MatchingStatusRow.builder()
+                        .vi(viUser)
+                        .guides(Collections.emptyList())
+                        .build());
+                continue;
+            }
+            if (flat.getType() != UserType.GUIDE) continue;
             MatchingStatusUser guideUser = MatchingStatusUser.builder()
                     .userId(flat.getUserId())
                     .name(flat.getName())

--- a/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
@@ -3,6 +3,9 @@ package com.guide.run.event.service;
 import com.guide.run.attendance.repository.AttendanceRepository;
 import com.guide.run.event.entity.Event;
 import com.guide.run.event.entity.EventForm;
+import com.guide.run.event.entity.dto.response.match.EventMatchingStatusResponse;
+import com.guide.run.event.entity.dto.response.match.MatchingStatusGroup;
+import com.guide.run.event.entity.dto.response.match.MatchingWaitingFlatDto;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.EventFormStatus;
@@ -21,6 +24,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -110,5 +114,61 @@ class EventMatchingServiceTest {
         assertThat(savedMatching.getGuideRecord()).isEqualTo("GUIDE-APPLIED");
         verify(eventFormRepository).findByEventIdAndPrivateIdAndStatus(1L, "vi-private", EventFormStatus.APPLIED);
         verify(eventFormRepository).findByEventIdAndPrivateIdAndStatus(1L, "guide-private", EventFormStatus.APPLIED);
+    }
+
+    @Test
+    @DisplayName("매칭 현황은 미매칭 VI도 신청 그룹의 독립 행으로 반환한다")
+    void getMatchingStatusIncludesUnmatchedViRows() {
+        User loginUser = User.builder()
+                .privateId("login-guide-private")
+                .userId("login-guide-user")
+                .type(UserType.GUIDE)
+                .build();
+        MatchingWaitingFlatDto waitingVi = new MatchingWaitingFlatDto(
+                "vi-user",
+                "김민지",
+                UserType.VI,
+                "A",
+                "상관없음",
+                "천천히 출발하고 싶습니다.",
+                0,
+                0
+        );
+        MatchingWaitingFlatDto waitingGuide = new MatchingWaitingFlatDto(
+                "guide-user",
+                "정현우",
+                UserType.GUIDE,
+                "A",
+                "상관없음",
+                "안전하게 보조 가능합니다.",
+                0,
+                0
+        );
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(Event.builder().id(1L).build()));
+        when(userRepository.findUserByPrivateId("login-guide-private")).thenReturn(Optional.of(loginUser));
+        when(matchingRepository.findByEventIdAndGuideId(1L, "login-guide-private")).thenReturn(null);
+        when(matchingRepository.findMatchingCompletedByEventId(1L)).thenReturn(List.of());
+        when(unMatchingRepository.findWaitingParticipants(1L)).thenReturn(List.of(waitingVi, waitingGuide));
+
+        EventMatchingStatusResponse response = eventMatchingService.getMatchingStatus(1L, "login-guide-private");
+
+        assertThat(response.getGroups()).hasSize(1);
+        MatchingStatusGroup group = response.getGroups().get(0);
+        assertThat(group.getRunningGroup()).isEqualTo("A");
+        assertThat(group.getTotalCount()).isEqualTo(2);
+        assertThat(group.getRows())
+                .anySatisfy(row -> {
+                    assertThat(row.getVi()).isNotNull();
+                    assertThat(row.getVi().getUserId()).isEqualTo("vi-user");
+                    assertThat(row.getVi().getType()).isEqualTo(UserType.VI);
+                    assertThat(row.getGuides()).isEmpty();
+                })
+                .anySatisfy(row -> {
+                    assertThat(row.getVi()).isNull();
+                    assertThat(row.getGuides()).hasSize(1);
+                    assertThat(row.getGuides().get(0).getUserId()).isEqualTo("guide-user");
+                    assertThat(row.getGuides().get(0).getType()).isEqualTo(UserType.GUIDE);
+                });
     }
 }


### PR DESCRIPTION
## 변경 배경
매칭현황 API(`/api/event/{eventId}/matching/status`)에서 미매칭 참가자 중 Guide만 row로 추가하고 VI는 제외하고 있어, 매칭 전 VI 신청자가 현황 화면에 보이지 않는 문제가 있었습니다.

## 주요 변경 사항
- 미매칭 VI를 신청 그룹의 독립 row로 반환하도록 `EventMatchingService.getMatchingStatus` 수정
- 기존 미매칭 Guide는 기존처럼 `vi=null` row로 유지
- 미매칭 VI와 Guide가 같은 그룹에 있을 때 둘 다 반환되는 단위 테스트 추가

## 검증
- `./gradlew test --tests com.guide.run.event.service.EventMatchingServiceTest --rerun-tasks` 통과

## 기대 효과
- 매칭 전 상태에서도 VI 신청자가 매칭현황에 표시됩니다.
- 매칭 완료 VI, 미매칭 VI, 미매칭 Guide가 같은 API 응답에서 일관되게 그룹별로 확인됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 매칭 현황에서 미매칭 참가자 표시가 개선되었습니다.
  * 이제 `VI` 참가자는 신청 그룹을 독립 행으로 보여주고, `GUIDE` 참가자는 기존 방식대로 관련 행에 반영됩니다.
  * 매칭된 경우와 미매칭인 경우 모두 응답의 그룹/행 구조가 더 정확하게 표시되도록 수정되었습니다.

* **Tests**
  * 매칭 현황 응답에서 `VI`와 `GUIDE`가 각각 올바르게 반영되는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->