### PR TITLE
Fix: 미매칭 참가자 정렬 기준 적용

### DIFF
--- a/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
@@ -30,6 +30,16 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class EventMatchingService {
+    private static final Comparator<String> TEXT_ORDER = Comparator.nullsLast(String::compareTo);
+    private static final Comparator<MatchingStatusRow> MATCHING_STATUS_ROW_ORDER = Comparator
+            .comparingInt(EventMatchingService::matchingStatusRowUserTypeOrder)
+            .thenComparing(EventMatchingService::matchingStatusRowName, TEXT_ORDER)
+            .thenComparing(EventMatchingService::matchingStatusRowUserId, TEXT_ORDER);
+    private static final Comparator<MatchingWaitingParticipant> MATCHING_WAITING_PARTICIPANT_ORDER = Comparator
+            .comparingInt((MatchingWaitingParticipant participant) -> userTypeOrder(participant.getType()))
+            .thenComparing(MatchingWaitingParticipant::getName, TEXT_ORDER)
+            .thenComparing(MatchingWaitingParticipant::getUserId, TEXT_ORDER);
+
     private final UnMatchingRepository unMatchingRepository;
     private final MatchingRepository matchingRepository;
     private final UserRepository userRepository;
@@ -344,7 +354,9 @@ public class EventMatchingService {
         List<MatchingStatusGroup> groups = groupRowMap.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
                 .map(e -> {
-                    List<MatchingStatusRow> rows = new ArrayList<>(e.getValue().values());
+                    List<MatchingStatusRow> rows = e.getValue().values().stream()
+                            .sorted(MATCHING_STATUS_ROW_ORDER)
+                            .collect(Collectors.toList());
                     return MatchingStatusGroup.builder()
                             .runningGroup(e.getKey())
                             .totalCount(rows.size())
@@ -425,10 +437,13 @@ public class EventMatchingService {
         }
 
         List<MatchingWaitingGroup> groups = groupMap.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
                 .map(e -> MatchingWaitingGroup.builder()
                         .runningGroup(e.getKey())
                         .totalCount(e.getValue().size())
-                        .participants(e.getValue())
+                        .participants(e.getValue().stream()
+                                .sorted(MATCHING_WAITING_PARTICIPANT_ORDER)
+                                .collect(Collectors.toList()))
                         .build())
                 .collect(Collectors.toList());
 
@@ -594,6 +609,51 @@ public class EventMatchingService {
             partnerService.setAttendGuidePartner(eventId, guide);
         }
         }
+
+    private static int matchingStatusRowUserTypeOrder(MatchingStatusRow row) {
+        if (row.getVi() != null) {
+            return userTypeOrder(row.getVi().getType());
+        }
+        return firstGuide(row)
+                .map(MatchingStatusUser::getType)
+                .map(EventMatchingService::userTypeOrder)
+                .orElse(Integer.MAX_VALUE);
+    }
+
+    private static String matchingStatusRowName(MatchingStatusRow row) {
+        if (row.getVi() != null) {
+            return row.getVi().getName();
+        }
+        return firstGuide(row)
+                .map(MatchingStatusUser::getName)
+                .orElse(null);
+    }
+
+    private static String matchingStatusRowUserId(MatchingStatusRow row) {
+        if (row.getVi() != null) {
+            return row.getVi().getUserId();
+        }
+        return firstGuide(row)
+                .map(MatchingStatusUser::getUserId)
+                .orElse(null);
+    }
+
+    private static Optional<MatchingStatusUser> firstGuide(MatchingStatusRow row) {
+        if (row.getGuides() == null || row.getGuides().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(row.getGuides().get(0));
+    }
+
+    private static int userTypeOrder(UserType type) {
+        if (type == UserType.VI) {
+            return 0;
+        }
+        if (type == UserType.GUIDE) {
+            return 1;
+        }
+        return Integer.MAX_VALUE;
+    }
 
     /*
     public int autoMatchBetweenTwoGroup(List<Form> vi,List<Form> guide){

--- a/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
@@ -5,6 +5,7 @@ import com.guide.run.event.entity.Event;
 import com.guide.run.event.entity.EventForm;
 import com.guide.run.event.entity.dto.response.match.EventMatchingStatusResponse;
 import com.guide.run.event.entity.dto.response.match.MatchingStatusGroup;
+import com.guide.run.event.entity.dto.response.match.MatchingWaitingResponse;
 import com.guide.run.event.entity.dto.response.match.MatchingWaitingFlatDto;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
@@ -170,5 +171,94 @@ class EventMatchingServiceTest {
                     assertThat(row.getGuides().get(0).getUserId()).isEqualTo("guide-user");
                     assertThat(row.getGuides().get(0).getType()).isEqualTo(UserType.GUIDE);
                 });
+    }
+
+    @Test
+    @DisplayName("매칭 현황은 미매칭 참가자를 VI 먼저, Guide 나중, 각 타입 가나다순으로 반환한다")
+    void getMatchingStatusSortsUnmatchedRowsByTypeAndName() {
+        User loginUser = User.builder()
+                .privateId("login-guide-private")
+                .userId("login-guide-user")
+                .type(UserType.GUIDE)
+                .build();
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(Event.builder().id(1L).build()));
+        when(userRepository.findUserByPrivateId("login-guide-private")).thenReturn(Optional.of(loginUser));
+        when(matchingRepository.findByEventIdAndGuideId(1L, "login-guide-private")).thenReturn(null);
+        when(matchingRepository.findMatchingCompletedByEventId(1L)).thenReturn(List.of());
+        when(unMatchingRepository.findWaitingParticipants(1L)).thenReturn(unsortedWaitingParticipants());
+
+        EventMatchingStatusResponse response = eventMatchingService.getMatchingStatus(1L, "login-guide-private");
+
+        List<String> orderedNames = response.getGroups().get(0).getRows().stream()
+                .map(row -> row.getVi() != null ? row.getVi().getName() : row.getGuides().get(0).getName())
+                .toList();
+        List<UserType> orderedTypes = response.getGroups().get(0).getRows().stream()
+                .map(row -> row.getVi() != null ? row.getVi().getType() : row.getGuides().get(0).getType())
+                .toList();
+        assertThat(orderedNames).containsExactly("김시각", "최시각", "김가이드", "하가이드");
+        assertThat(orderedTypes).containsExactly(UserType.VI, UserType.VI, UserType.GUIDE, UserType.GUIDE);
+    }
+
+    @Test
+    @DisplayName("매칭 대기는 미매칭 참가자를 VI 먼저, Guide 나중, 각 타입 가나다순으로 반환한다")
+    void getMatchingWaitingSortsParticipantsByTypeAndName() {
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(Event.builder().id(1L).build()));
+        when(unMatchingRepository.findWaitingParticipants(1L)).thenReturn(unsortedWaitingParticipants());
+
+        MatchingWaitingResponse response = eventMatchingService.getMatchingWaiting(1L);
+
+        assertThat(response.getGroups()).hasSize(1);
+        assertThat(response.getGroups().get(0).getParticipants())
+                .extracting("name")
+                .containsExactly("김시각", "최시각", "김가이드", "하가이드");
+        assertThat(response.getGroups().get(0).getParticipants())
+                .extracting("type")
+                .containsExactly(UserType.VI, UserType.VI, UserType.GUIDE, UserType.GUIDE);
+    }
+
+    private List<MatchingWaitingFlatDto> unsortedWaitingParticipants() {
+        return List.of(
+                new MatchingWaitingFlatDto(
+                        "guide-ha",
+                        "하가이드",
+                        UserType.GUIDE,
+                        "A",
+                        "상관없음",
+                        "가이드 먼저 들어온 원본 순서입니다.",
+                        0,
+                        0
+                ),
+                new MatchingWaitingFlatDto(
+                        "vi-choi",
+                        "최시각",
+                        UserType.VI,
+                        "A",
+                        "상관없음",
+                        "시각 참가자입니다.",
+                        0,
+                        0
+                ),
+                new MatchingWaitingFlatDto(
+                        "guide-kim",
+                        "김가이드",
+                        UserType.GUIDE,
+                        "A",
+                        "상관없음",
+                        "가이드 참가자입니다.",
+                        0,
+                        0
+                ),
+                new MatchingWaitingFlatDto(
+                        "vi-kim",
+                        "김시각",
+                        UserType.VI,
+                        "A",
+                        "상관없음",
+                        "시각 참가자입니다.",
+                        0,
+                        0
+                )
+        );
     }
 }


### PR DESCRIPTION
## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
- 매칭 현황에서 미매칭 참가자 row 정렬 기준 추가
- 매칭 대기 목록 참가자 정렬 기준도 동일하게 적용
- VI 우선, Guide 후순위, 각 타입 내부 이름 가나다순 정렬 테스트 추가

## **변경 내용**
- `matching/status` 응답의 그룹 row를 VI 먼저, Guide 나중으로 정렬합니다.
- 같은 타입 안에서는 이름 가나다순으로 정렬하고, 동명이인 대비 userId를 보조 정렬 기준으로 사용합니다.
- `matching/waiting` 응답도 같은 정렬 기준을 사용하도록 정리했습니다.

## **관련 이슈**
Resolves: 없음

See also: 없음
