### PR TITLE
fix: 진행중 이벤트를 예정 조회에 포함

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -77,7 +77,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                     .from(event)
                     .join(eventForm).on(event.id.eq(eventForm.eventId),
                             eventForm.privateId.eq(privateId))
-                    .where(checkByUpcomingDate()
+                    .where(checkByNotEndedDateTime()
                             .and(event.isApprove.eq(true))
                             .and(event.startTime.year().eq(year))
                             .and(event.id.eq(eventForm.eventId))
@@ -181,7 +181,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .from(event)
                 .join(eventForm).on(event.id.eq(eventForm.eventId),
                         eventForm.privateId.eq(privateId))
-                .where(checkByUpcomingDate()
+                .where(checkByNotEndedDateTime()
                         .and(event.isApprove.eq(true))
                         .and(eventForm.eventId.eq(event.id))
                         .and(eventForm.privateId.eq(privateId)))
@@ -230,7 +230,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(event.isApprove.eq(true))
                         .and(checkByCityName(cityName))
                         .and(checkByPublicEvent())
-                        .and(checkByUpcomingDate())
+                        .and(checkByNotEndedDateTime())
                 )
                 .fetchOne();
         return result != null ? result : 0L;
@@ -290,7 +290,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(event.isApprove.eq(true))
                         .and(checkByCityName(cityName))
                         .and(checkByPublicEvent())
-                        .and(checkByUpcomingDate())
+                        .and(checkByNotEndedDateTime())
                 )
                 .orderBy(event.startTime.asc())
                 .offset(start)
@@ -386,7 +386,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(checkByCityName(cityName))
                         .and(checkByPublicEvent())
                         .and(checkByTitle(title))
-                        .and(checkByUpcomingDate())
+                        .and(checkByNotEndedDateTime())
                 )
                 .orderBy(event.startTime.asc())
                 .offset(start)
@@ -455,7 +455,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         .and(checkByCityName(cityName))
                         .and(checkByPublicEvent())
                         .and(checkByTitle(title))
-                        .and(checkByUpcomingDate())
+                        .and(checkByNotEndedDateTime())
                 )
                 .fetchOne();
         return result != null ? result : 0L;
@@ -615,8 +615,8 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
         }
     }
 
-    private BooleanBuilder checkByUpcomingDate() {
-        return new BooleanBuilder(event.startTime.gt(EventTemporalStatusResolver.now()));
+    private BooleanBuilder checkByNotEndedDateTime() {
+        return new BooleanBuilder(event.endTime.gt(EventTemporalStatusResolver.now()));
     }
 
     private BooleanBuilder checkByPastDateTime() {

--- a/run/src/main/java/com/guide/run/event/service/EventGetService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventGetService.java
@@ -230,7 +230,8 @@ public class EventGetService {
         return event != null
                 && event.isApprove()
                 && event.getStartTime() != null
-                && event.getStartTime().isAfter(EventTemporalStatusResolver.now());
+                && event.getEndTime() != null
+                && event.getEndTime().isAfter(EventTemporalStatusResolver.now());
     }
 
     private int getDDay(LocalDate date) {

--- a/run/src/test/java/com/guide/run/event/entity/repository/EventRepositoryImplTest.java
+++ b/run/src/test/java/com/guide/run/event/entity/repository/EventRepositoryImplTest.java
@@ -1,0 +1,28 @@
+package com.guide.run.event.entity.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class EventRepositoryImplTest {
+
+    @Test
+    @DisplayName("예정 이벤트 조건은 시작 전이 아니라 종료 전 이벤트를 대상으로 한다")
+    void upcomingDatePredicateUsesEndTime() throws Exception {
+        EventRepositoryImpl repository = new EventRepositoryImpl(mock(EntityManager.class));
+        Method method = EventRepositoryImpl.class.getDeclaredMethod("checkByNotEndedDateTime");
+        method.setAccessible(true);
+
+        BooleanBuilder predicate = (BooleanBuilder) method.invoke(repository);
+
+        assertThat(predicate.toString())
+                .contains("event.endTime")
+                .doesNotContain("event.startTime");
+    }
+}

--- a/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
@@ -44,7 +44,7 @@ class EventGetServiceTest {
     private EventGetService eventGetService;
 
     @Test
-    @DisplayName("예정 이벤트 카운트는 시작일 필터가 포함된 전용 쿼리를 사용한다")
+    @DisplayName("예정 이벤트 카운트는 종료 전 필터가 포함된 전용 쿼리를 사용한다")
     void getAllEventListCountUsesUpcomingCountQuery() {
         when(eventRepository.countUpcomingEventList(null, EventRecruitStatus.RECRUIT_ALL, null))
                 .thenReturn(7L);
@@ -137,8 +137,8 @@ class EventGetServiceTest {
     }
 
     @Test
-    @DisplayName("회원 다가오는 이벤트는 저장 상태가 모집중이어도 이미 시작했으면 제외한다")
-    void getUpcomingEventsExcludesStartedEventWithStaleOpenStatus() {
+    @DisplayName("회원 다가오는 이벤트는 이미 시작했어도 종료 전이면 반환한다")
+    void getUpcomingEventsIncludesStartedEventBeforeEndTime() {
         User member = User.builder()
                 .privateId("member-private")
                 .role(Role.ROLE_USER)
@@ -157,7 +157,7 @@ class EventGetServiceTest {
 
         var response = eventGetService.getUpcomingEvents("member-private");
 
-        assertThat(response.getItems()).isEmpty();
+        assertThat(response.getItems()).hasSize(1);
     }
 
     private Event createEvent(Long id, EventRecruitStatus recruitStatus, LocalDateTime startTime) {

--- a/run/src/test/java/com/guide/run/event/service/EventSearchServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventSearchServiceTest.java
@@ -29,7 +29,7 @@ class EventSearchServiceTest {
     private EventSearchService eventSearchService;
 
     @Test
-    @DisplayName("예정 이벤트 검색 카운트는 시작일 필터가 포함된 전용 쿼리를 사용한다")
+    @DisplayName("예정 이벤트 검색 카운트는 종료 전 필터가 포함된 전용 쿼리를 사용한다")
     void getSearchAllEventsCountValueUsesUpcomingSearchCountQuery() {
         when(eventRepository.upcomingGetSearchEventListCount("러닝", null, EventRecruitStatus.RECRUIT_ALL, null))
                 .thenReturn(3L);

--- a/run/src/test/java/com/guide/run/event/service/EventTemporalStatusResolverTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventTemporalStatusResolverTest.java
@@ -143,11 +143,14 @@ class EventTemporalStatusResolverTest {
     @Test
     @DisplayName("모집 상태 raw 필드 계산은 같은 현재 시각에서 날짜를 파생한다")
     void resolveRecruitStatusWithRawFieldsDerivesTodayFromSameNow() {
+        LocalDate serviceToday = EventTemporalStatusResolver.today();
+        LocalDateTime serviceNow = EventTemporalStatusResolver.now();
+
         EventRecruitStatus status = EventTemporalStatusResolver.resolveRecruitStatus(
                 EventRecruitStatus.RECRUIT_UPCOMING,
-                today.minusDays(1),
-                today.plusDays(1),
-                now.plusDays(2)
+                serviceToday.minusDays(1),
+                serviceToday.plusDays(1),
+                serviceNow.plusDays(2)
         );
 
         assertThat(status).isEqualTo(EventRecruitStatus.RECRUIT_OPEN);


### PR DESCRIPTION
## 변경 배경
현재 예정/다가오는 이벤트 조회가 `startTime > now` 기준으로 필터링되어, 이미 시작했지만 아직 종료되지 않은 진행중 이벤트가 목록에서 빠지는 문제가 있었습니다.

## 주요 변경 사항
- UPCOMING 계열 이벤트 조회 조건을 `startTime` 기준에서 `endTime > now` 기준으로 변경
- 회원용 `/api/event/upcoming` 필터도 종료 전 이벤트를 포함하도록 변경
- 진행중 이벤트 포함 회귀 테스트 추가
- 날짜 고정으로 깨질 수 있던 모집 상태 resolver 테스트를 현재 서비스 날짜 기준으로 안정화

## 검증
- `./gradlew test --rerun-tasks --tests 'com.guide.run.event.*'` 성공
- `git diff --check` 성공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 예정/진행중 이벤트의 기준이 시작 시각이 아닌 종료 시각으로 바뀌어, 이미 시작했더라도 아직 끝나지 않은 이벤트가 목록과 집계에 포함됩니다.
  * 다가오는 이벤트와 D-day 계산도 종료 전 상태를 기준으로 더 일관되게 표시됩니다.

* **테스트**
  * 변경된 이벤트 기준에 맞춰 관련 검증 시나리오와 기대 결과를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->