### PR TITLE
fix: 출석 응답에 첫 참여 여부 추가

### DIFF
--- a/run/src/main/java/com/guide/run/attendance/repository/AttendanceRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/attendance/repository/AttendanceRepositoryImpl.java
@@ -54,7 +54,8 @@ public class AttendanceRepositoryImpl implements AttendanceCustomRepository{
         return queryFactory.select(Projections.constructor(AttendanceParticipant.class,
                 user.userId.as("userId"),
                 user.name.as("name"),
-                user.type.as("type")))
+                user.type.as("type"),
+                user.trainingCnt.add(user.competitionCnt).eq(0)))
                 .from(attendance)
                 .join(user).on(attendance.privateId.eq(user.privateId))
                 .where(attendance.isAttend.eq(isAttend).and(attendance.eventId.eq(eventId)))

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/attend/AttendanceParticipant.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/attend/AttendanceParticipant.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.entity.dto.response.attend;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.guide.run.user.entity.type.UserType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,4 +13,7 @@ public class AttendanceParticipant {
     private String userId;
     private String name;
     private UserType type;
+    @JsonProperty("isFirstParticipation")
+    @Builder.Default
+    private Boolean isFirstParticipation = false;
 }

--- a/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventResponseContractTest.java
@@ -2,6 +2,7 @@ package com.guide.run.event.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guide.run.event.entity.dto.response.attend.AttendanceParticipant;
 import com.guide.run.event.entity.dto.response.comments.GetComment;
 import com.guide.run.event.entity.dto.response.get.AllEvent;
 import com.guide.run.event.entity.dto.response.get.AllEventResponse;
@@ -159,5 +160,43 @@ class EventResponseContractTest {
         JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(comment));
 
         assertThat(json.at("/createdAt").asText()).isEqualTo("2026-06-24T13:45:30");
+    }
+
+    @Test
+    @DisplayName("출석 참가자 응답은 첫 참여 여부를 isFirstParticipation 필드로 내려준다")
+    void attendanceParticipantUsesIsFirstParticipationContract() throws Exception {
+        AttendanceParticipant participant = AttendanceParticipant.builder()
+                .userId("guide-101")
+                .name("홍길동")
+                .type(UserType.GUIDE)
+                .build();
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(participant));
+
+        assertThat(json.at("/isFirstParticipation").isMissingNode()).isFalse();
+        assertThat(json.at("/isFirstParticipation").isBoolean()).isTrue();
+        assertThat(json.at("/firstParticipation").isMissingNode()).isTrue();
+    }
+
+    @Test
+    @DisplayName("출석 참가자 응답은 projection에서 계산한 첫 참여 true 값을 담을 수 있다")
+    void attendanceParticipantConstructorAcceptsFirstParticipationValue() throws Exception {
+        var constructor = AttendanceParticipant.class.getConstructor(
+                String.class,
+                String.class,
+                UserType.class,
+                Boolean.class
+        );
+        AttendanceParticipant participant = constructor.newInstance(
+                "vi-101",
+                "김가나",
+                UserType.VI,
+                true
+        );
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(participant));
+
+        assertThat(json.at("/isFirstParticipation").asBoolean()).isTrue();
+        assertThat(json.at("/firstParticipation").isMissingNode()).isTrue();
     }
 }


### PR DESCRIPTION
## 변경 배경
출석 페이지 프론트엔드는 참가자 응답의 `isFirstParticipation` 값을 기준으로 `첫참여` 배지를 렌더링하지만, 백엔드 출석 조회 응답에는 해당 필드가 내려가지 않았습니다.

## 주요 변경 사항
- `GET /event/{eventId}/attendance`의 참가자 응답 DTO에 `isFirstParticipation` 필드 추가
- 출석 참가자 조회 projection에서 `trainingCnt + competitionCnt == 0` 여부를 계산해 응답에 포함
- Jackson 직렬화 키가 프론트 계약과 맞도록 `isFirstParticipation`으로 고정
- 응답 계약 테스트 추가

## 검증
- `./gradlew test --rerun-tasks --tests "com.guide.run.event.service.EventResponseContractTest"` 통과
- `git diff --check` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 출석 참여자 응답에 첫 참여 여부가 포함되도록 개선했습니다.
  * 응답 JSON에서 `isFirstParticipation` 값이 항상 boolean으로 전달되며, 기본값은 `false`입니다.
  * 관련 직렬화 결과가 일관되도록 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->