### PR TITLE
fix: count matching group participants

### DIFF
--- a/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
@@ -359,7 +359,7 @@ public class EventMatchingService {
                             .collect(Collectors.toList());
                     return MatchingStatusGroup.builder()
                             .runningGroup(e.getKey())
-                            .totalCount(rows.size())
+                            .totalCount(countMatchingStatusPeople(rows))
                             .rows(rows)
                             .build();
                 })
@@ -505,7 +505,7 @@ public class EventMatchingService {
         List<MatchingCompletedGroup> groups = groupMap.entrySet().stream()
                 .map(e -> MatchingCompletedGroup.builder()
                         .runningGroup(e.getKey())
-                        .totalCount(e.getValue().size())
+                        .totalCount(countMatchingCompletedPeople(e.getValue()))
                         .rows(e.getValue())
                         .build())
                 .collect(Collectors.toList());
@@ -643,6 +643,34 @@ public class EventMatchingService {
             return Optional.empty();
         }
         return Optional.ofNullable(row.getGuides().get(0));
+    }
+
+    private static int countMatchingStatusPeople(List<MatchingStatusRow> rows) {
+        return rows.stream()
+                .mapToInt(EventMatchingService::countMatchingStatusRowPeople)
+                .sum();
+    }
+
+    private static int countMatchingStatusRowPeople(MatchingStatusRow row) {
+        int count = row.getVi() != null ? 1 : 0;
+        if (row.getGuides() != null) {
+            count += row.getGuides().size();
+        }
+        return count;
+    }
+
+    private static int countMatchingCompletedPeople(List<MatchingCompletedRow> rows) {
+        return rows.stream()
+                .mapToInt(EventMatchingService::countMatchingCompletedRowPeople)
+                .sum();
+    }
+
+    private static int countMatchingCompletedRowPeople(MatchingCompletedRow row) {
+        int count = row.getVi() != null ? 1 : 0;
+        if (row.getGuides() != null) {
+            count += row.getGuides().size();
+        }
+        return count;
     }
 
     private static int userTypeOrder(UserType type) {

--- a/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
@@ -4,6 +4,8 @@ import com.guide.run.attendance.repository.AttendanceRepository;
 import com.guide.run.event.entity.Event;
 import com.guide.run.event.entity.EventForm;
 import com.guide.run.event.entity.dto.response.match.EventMatchingStatusResponse;
+import com.guide.run.event.entity.dto.response.match.MatchingCompletedFlatDto;
+import com.guide.run.event.entity.dto.response.match.MatchingCompletedResponse;
 import com.guide.run.event.entity.dto.response.match.MatchingStatusGroup;
 import com.guide.run.event.entity.dto.response.match.MatchingWaitingResponse;
 import com.guide.run.event.entity.dto.response.match.MatchingWaitingFlatDto;
@@ -201,6 +203,51 @@ class EventMatchingServiceTest {
     }
 
     @Test
+    @DisplayName("매칭 현황 그룹 totalCount는 row 수가 아니라 그룹에 표시되는 전체 인원 수를 반환한다")
+    void getMatchingStatusCountsPeopleInGroup() {
+        User loginUser = User.builder()
+                .privateId("login-guide-private")
+                .userId("login-guide-user")
+                .type(UserType.GUIDE)
+                .build();
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(Event.builder().id(1L).build()));
+        when(userRepository.findUserByPrivateId("login-guide-private")).thenReturn(Optional.of(loginUser));
+        when(matchingRepository.findByEventIdAndGuideId(1L, "login-guide-private")).thenReturn(null);
+        when(matchingRepository.findMatchingCompletedByEventId(1L)).thenReturn(List.of(
+                matchedFlat("vi-a", "김시각", "A", "guide-b", "박가이드", "B"),
+                matchedFlat("vi-a", "김시각", "A", "guide-c", "이가이드", "C")
+        ));
+        when(unMatchingRepository.findWaitingParticipants(1L)).thenReturn(List.of());
+
+        EventMatchingStatusResponse response = eventMatchingService.getMatchingStatus(1L, "login-guide-private");
+
+        assertThat(response.getGroups()).hasSize(1);
+        assertThat(response.getGroups().get(0).getRunningGroup()).isEqualTo("A");
+        assertThat(response.getGroups().get(0).getRows()).hasSize(1);
+        assertThat(response.getGroups().get(0).getTotalCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("매칭 완료 그룹 totalCount는 row 수가 아니라 그룹에 표시되는 전체 인원 수를 반환한다")
+    void getMatchingCompletedCountsPeopleInGroup() {
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(Event.builder().id(1L).build()));
+        when(matchingRepository.findMatchingCompletedByEventId(1L)).thenReturn(List.of(
+                matchedFlat("vi-a", "김시각", "A", "guide-b", "박가이드", "B"),
+                matchedFlat("vi-a", "김시각", "A", "guide-c", "이가이드", "C")
+        ));
+
+        MatchingCompletedResponse response = eventMatchingService.getMatchingCompleted(1L);
+
+        assertThat(response.getGroups()).hasSize(1);
+        assertThat(response.getGroups().get(0).getRunningGroup()).isEqualTo("A");
+        assertThat(response.getGroups().get(0).getRows()).hasSize(1);
+        assertThat(response.getGroups().get(0).getTotalCount()).isEqualTo(3);
+        assertThat(response.getSummary().getCompletedViCount()).isEqualTo(1);
+        assertThat(response.getSummary().getMatchedGuideCount()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("매칭 대기는 미매칭 참가자를 VI 먼저, Guide 나중, 각 타입 가나다순으로 반환한다")
     void getMatchingWaitingSortsParticipantsByTypeAndName() {
         when(eventRepository.findById(1L)).thenReturn(Optional.of(Event.builder().id(1L).build()));
@@ -259,6 +306,31 @@ class EventMatchingServiceTest {
                         0,
                         0
                 )
+        );
+    }
+
+    private MatchingCompletedFlatDto matchedFlat(
+            String viUserId,
+            String viName,
+            String viGroup,
+            String guideUserId,
+            String guideName,
+            String guideGroup
+    ) {
+        return new MatchingCompletedFlatDto(
+                viUserId,
+                UserType.VI,
+                viName,
+                viGroup,
+                false,
+                viGroup,
+                viGroup,
+                guideUserId,
+                UserType.GUIDE,
+                guideName,
+                guideGroup,
+                false,
+                guideGroup
         );
     }
 }


### PR DESCRIPTION
## 변경 배경
이벤트 상세의 매칭 현황/매칭 완료 그룹 `totalCount`가 실제 인원 수가 아니라 row 수로 계산되어, VI 1명에 여러 Guide가 매칭된 경우 그룹별 인원이 적게 표시되었습니다.

## 주요 변경 사항
- `matching/status` 그룹 `totalCount`를 row 수 대신 `VI + Guide` 인원 수 합산으로 변경
- `matching/completed` 그룹 `totalCount`도 동일하게 인원 수 합산으로 변경
- VI 1명 + Guide 2명 매칭 케이스에 대한 회귀 테스트 추가

## 검증
- `./gradlew test --rerun-tasks --tests "*EventMatchingServiceTest"` 성공
- `git diff --check` 성공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 매칭 상태와 매칭 완료 화면에서 전체 인원 수가 단순 행 개수가 아니라, 실제 표시되는 인원 기준으로 정확히 집계되도록 수정했습니다.
  * 가이드 정보가 없는 경우에도 인원 수가 올바르게 계산되도록 처리했습니다.
* **Tests**
  * 전체 인원 수 집계가 올바른지 확인하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->