### PR TITLE
fix: limit event and comment text length

### DIFF
--- a/run/src/main/java/com/guide/run/event/controller/EventCommentController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventCommentController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +28,7 @@ public class EventCommentController {
     @PostMapping("/{eventId}/comments")
     public ResponseEntity<CommentsCreatedResponse> createComment(@PathVariable Long eventId,
                                                                  HttpServletRequest request,
-                                                                 @RequestBody EventCommentCreateRequest eventCommentCreateRequest){
+                                                                 @RequestBody @Valid EventCommentCreateRequest eventCommentCreateRequest){
         String userId = jwtProvider.extractUserId(request);
         return ResponseEntity.status(200).body(CommentsCreatedResponse.builder()
                 .commentId(eventCommentService.createComment(eventId,userId,eventCommentCreateRequest)).build());
@@ -45,7 +46,7 @@ public class EventCommentController {
     @PatchMapping("/{eventId}/comments/{commentId}")
     public ResponseEntity<CommentsCreatedResponse> patchComment(@PathVariable Long eventId,
                                                                  @PathVariable Long commentId,
-                                                                @RequestBody EventCommentCreateRequest eventCommentCreateRequest,
+                                                                @RequestBody @Valid EventCommentCreateRequest eventCommentCreateRequest,
                                                                  HttpServletRequest request){
         String userId = jwtProvider.extractUserId(request);
         return ResponseEntity.status(200).body(CommentsCreatedResponse.builder()

--- a/run/src/main/java/com/guide/run/event/controller/EventController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +35,7 @@ public class EventController {
 
     @Operation(summary = "이벤트 생성", description = "신규 이벤트 생성 화면에서 이벤트를 등록합니다. 생성 직후 스케줄러 등록이 함께 수행됩니다.")
     @PostMapping
-    public ResponseEntity<EventCreatedResponse> eventCreate(@RequestBody EventCreateRequest request, HttpServletRequest httpServletRequest){
+    public ResponseEntity<EventCreatedResponse> eventCreate(@RequestBody @Valid EventCreateRequest request, HttpServletRequest httpServletRequest){
         String privateId = jwtProvider.extractUserId(httpServletRequest);
         EventCreatedResponse eventCreatedResponse = eventService.eventCreate(request, privateId);
         //스케줄러에 등록
@@ -76,7 +77,7 @@ public class EventController {
 
     @Operation(summary = "이벤트 수정", description = "이벤트 수정 화면에서 기존 이벤트를 수정합니다. 수정 후 스케줄러 정보도 함께 갱신됩니다.")
     @PatchMapping("/{eventId}")
-    public ResponseEntity<EventUpdatedResponse> eventUpdate(@PathVariable Long eventId,@RequestBody EventCreateRequest request, HttpServletRequest httpServletRequest){
+    public ResponseEntity<EventUpdatedResponse> eventUpdate(@PathVariable Long eventId,@RequestBody @Valid EventCreateRequest request, HttpServletRequest httpServletRequest){
         String priavateId = jwtProvider.extractUserId(httpServletRequest);
         EventUpdatedResponse eventUpdatedResponse = eventService.eventUpdate(request, priavateId,eventId);
         //스케줄러에 등록

--- a/run/src/main/java/com/guide/run/event/entity/Comment.java
+++ b/run/src/main/java/com/guide/run/event/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.guide.run.event.entity;
 
 import com.guide.run.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,6 +20,7 @@ public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
+    @Column(length = 500)
     private String comment;
     private String privateId;
     private Long eventId;

--- a/run/src/main/java/com/guide/run/event/entity/Event.java
+++ b/run/src/main/java/com/guide/run/event/entity/Event.java
@@ -42,6 +42,7 @@ public class Event extends BaseEntity {
     private int maxNumV;//vi 모집 인원
     private int maxNumG;//guide 모집 인원
     private String place;//이벤트 장소
+    @Column(length = 1000)
     private String content;//이벤트 내용
 
     //이 부분 추가됐습니다~

--- a/run/src/main/java/com/guide/run/event/entity/dto/request/EventCommentCreateRequest.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/request/EventCommentCreateRequest.java
@@ -2,12 +2,14 @@ package com.guide.run.event.entity.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 @Schema(description = "이벤트 댓글 작성/수정 요청")
 public class EventCommentCreateRequest {
     @Schema(description = "댓글 내용", example = "이번 주 토요일에도 참여할게요.")
+    @Size(max = 500, message = "댓글은 500자 이하로 입력해주세요.")
     private String content;
 
     //dto json 변환시 객체 하나만 있으면 파업하므로 아래 어노테이션 붙여줘야함

--- a/run/src/main/java/com/guide/run/event/entity/dto/request/EventCreateRequest.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/request/EventCreateRequest.java
@@ -5,6 +5,7 @@ import com.guide.run.event.entity.type.CityName;
 import com.guide.run.event.entity.type.AdditionalQuestionType;
 import com.guide.run.event.entity.type.EventCategory;
 import com.guide.run.event.entity.type.EventType;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,6 +39,7 @@ public class EventCreateRequest {
     @Schema(description = "이벤트 장소", example = "서울 상계천천히공원")
     private String place;//이벤트 장소
     @Schema(description = "이벤트 상세 내용", example = "초급자 대상 오전 러닝 행사")
+    @Size(max = 1000, message = "이벤트 내용은 1000자 이하로 입력해주세요.")
     private String content;//이벤트 내용
     @Schema(description = "이벤트 카테고리", example = "TEAM")
     private EventCategory eventCategory; //이벤트 유형

--- a/run/src/test/java/com/guide/run/event/controller/EventTextLengthValidationTest.java
+++ b/run/src/test/java/com/guide/run/event/controller/EventTextLengthValidationTest.java
@@ -1,0 +1,112 @@
+package com.guide.run.event.controller;
+
+import com.guide.run.event.entity.Comment;
+import com.guide.run.event.entity.Event;
+import com.guide.run.event.entity.dto.request.EventCommentCreateRequest;
+import com.guide.run.event.entity.dto.request.EventCreateRequest;
+import jakarta.persistence.Column;
+import jakarta.validation.Valid;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.Size;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventTextLengthValidationTest {
+
+    private final Validator validator = createValidator();
+
+    @Test
+    @DisplayName("이벤트 생성/수정 요청 content는 1000자 초과를 검증 실패로 처리한다")
+    void eventContentRejectsMoreThan1000Characters() throws Exception {
+        Field field = EventCreateRequest.class.getDeclaredField("content");
+        Size size = field.getAnnotation(Size.class);
+
+        assertThat(size).isNotNull();
+        assertThat(size.max()).isEqualTo(1000);
+        assertThat(validator.validate(eventRequestWithContent("a".repeat(1000)))).isEmpty();
+        assertThat(validator.validate(eventRequestWithContent("a".repeat(1001))))
+                .anySatisfy(violation -> assertThat(violation.getPropertyPath().toString()).isEqualTo("content"));
+    }
+
+    @Test
+    @DisplayName("댓글 생성/수정 요청 content는 500자 초과를 검증 실패로 처리한다")
+    void commentContentRejectsMoreThan500Characters() throws Exception {
+        Field field = EventCommentCreateRequest.class.getDeclaredField("content");
+        Size size = field.getAnnotation(Size.class);
+
+        assertThat(size).isNotNull();
+        assertThat(size.max()).isEqualTo(500);
+        assertThat(validator.validate(new EventCommentCreateRequest("a".repeat(500)))).isEmpty();
+        assertThat(validator.validate(new EventCommentCreateRequest("a".repeat(501))))
+                .anySatisfy(violation -> assertThat(violation.getPropertyPath().toString()).isEqualTo("content"));
+    }
+
+    @Test
+    @DisplayName("이벤트와 댓글 저장 컬럼 길이는 요청 제한과 동일하게 명시한다")
+    void entityColumnsDeclareTextLengthLimits() throws Exception {
+        Column eventContentColumn = Event.class.getDeclaredField("content").getAnnotation(Column.class);
+        Column commentColumn = Comment.class.getDeclaredField("comment").getAnnotation(Column.class);
+
+        assertThat(eventContentColumn).isNotNull();
+        assertThat(eventContentColumn.length()).isEqualTo(1000);
+        assertThat(commentColumn).isNotNull();
+        assertThat(commentColumn.length()).isEqualTo(500);
+    }
+
+    @Test
+    @DisplayName("이벤트와 댓글 컨트롤러는 요청 DTO 검증을 활성화한다")
+    void controllersValidateLengthLimitedRequests() {
+        assertThat(hasValidRequestParameter(EventController.class, "eventCreate", EventCreateRequest.class)).isTrue();
+        assertThat(hasValidRequestParameter(EventController.class, "eventUpdate", EventCreateRequest.class)).isTrue();
+        assertThat(hasValidRequestParameter(EventCommentController.class, "createComment", EventCommentCreateRequest.class)).isTrue();
+        assertThat(hasValidRequestParameter(EventCommentController.class, "patchComment", EventCommentCreateRequest.class)).isTrue();
+    }
+
+    private static Validator createValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        return factory.getValidator();
+    }
+
+    private EventCreateRequest eventRequestWithContent(String content) {
+        return new EventCreateRequest(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                0,
+                0,
+                null,
+                content,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private boolean hasValidRequestParameter(Class<?> controllerClass, String methodName, Class<?> requestType) {
+        return Arrays.stream(controllerClass.getDeclaredMethods())
+                .filter(method -> method.getName().equals(methodName))
+                .map(Method::getParameters)
+                .flatMap(Arrays::stream)
+                .filter(parameter -> parameter.getType().equals(requestType))
+                .anyMatch(this::hasValidAnnotation);
+    }
+
+    private boolean hasValidAnnotation(Parameter parameter) {
+        return parameter.isAnnotationPresent(Valid.class);
+    }
+}


### PR DESCRIPTION
## 변경 배경
이벤트 본문과 댓글 내용에 서버 측 길이 제한이 없어 DB 컬럼 길이에 의존할 수 있는 상태였습니다. 이벤트 본문은 1000자, 댓글은 500자로 제한합니다.

## 주요 변경 사항
- 이벤트 생성/수정 요청 `content`에 최대 1000자 검증 추가
- 댓글 생성/수정 요청 `content`에 최대 500자 검증 추가
- 이벤트/댓글 컨트롤러 요청 DTO에 `@Valid` 적용
- `Event.content`는 `VARCHAR(1000)`, `Comment.comment`는 `VARCHAR(500)`로 JPA 컬럼 길이 명시
- DTO 검증, 컨트롤러 검증 활성화, 엔티티 컬럼 길이 회귀 테스트 추가

## DB 반영 쿼리
```sql
ALTER TABLE `guiderun`.`event`
    MODIFY COLUMN `content` VARCHAR(1000);

ALTER TABLE `guiderun`.`comment`
    MODIFY COLUMN `comment` VARCHAR(500);
```

## 검증
- `./gradlew test --rerun-tasks --tests "*EventTextLengthValidationTest"` 성공
- `git diff --check` 성공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 이벤트 및 댓글 작성/수정 시 입력값 검증이 적용되어, 너무 긴 내용은 저장되지 않도록 개선되었습니다.
  * 이벤트 내용은 1000자, 댓글은 500자까지 허용됩니다.
  * 잘못된 길이의 요청은 더 일관되게 거부됩니다.

* **Tests**
  * 이벤트/댓글 길이 제한과 요청 검증 적용 여부를 확인하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->