### PR TITLE
fix: 이벤트 요약 러닝 거리 집계 기준 수정

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -18,12 +18,14 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.guide.run.event.entity.QEvent.event;
 import static com.guide.run.event.entity.QEventForm.eventForm;
+import static com.guide.run.event.entity.type.EventFormStatus.APPLIED;
 import static com.guide.run.event.entity.type.EventRecruitStatus.*;
 import static java.time.temporal.ChronoUnit.DAYS;
 
@@ -568,12 +570,12 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
 
     @Override
     public double sumDistanceByYear(int year) {
-        Double result = queryFactory.select(event.distance.sum())
+        BigDecimal result = queryFactory.select(event.expectedRunningDistanceKm.sum())
                 .from(event)
                 .where(event.isApprove.eq(true)
                         .and(event.startTime.year().eq(year)))
                 .fetchOne();
-        return result != null ? result : 0.0;
+        return result != null ? result.doubleValue() : 0.0;
     }
 
     @Override
@@ -582,20 +584,24 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .from(eventForm)
                 .join(event).on(eventForm.eventId.eq(event.id))
                 .where(eventForm.privateId.eq(privateId)
-                        .and(event.isApprove.eq(true)))
+                        .and(eventForm.status.eq(APPLIED))
+                        .and(event.isApprove.eq(true))
+                        .and(checkByPastDateTime()))
                 .fetchOne();
         return result != null ? result : 0L;
     }
 
     @Override
     public double sumMyParticipationDistance(String privateId) {
-        Double result = queryFactory.select(event.distance.sum())
+        BigDecimal result = queryFactory.select(event.expectedRunningDistanceKm.sum())
                 .from(eventForm)
                 .join(event).on(eventForm.eventId.eq(event.id))
                 .where(eventForm.privateId.eq(privateId)
-                        .and(event.isApprove.eq(true)))
+                        .and(eventForm.status.eq(APPLIED))
+                        .and(event.isApprove.eq(true))
+                        .and(checkByPastDateTime()))
                 .fetchOne();
-        return result != null ? result : 0.0;
+        return result != null ? result.doubleValue() : 0.0;
     }
 
     private BooleanBuilder checkByTitle(String title) {

--- a/run/src/test/java/com/guide/run/event/entity/repository/EventRepositoryImplTest.java
+++ b/run/src/test/java/com/guide/run/event/entity/repository/EventRepositoryImplTest.java
@@ -2,13 +2,21 @@ package com.guide.run.event.entity.repository;
 
 import com.querydsl.core.BooleanBuilder;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Query;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.RETURNS_SELF;
 
 class EventRepositoryImplTest {
 
@@ -24,5 +32,69 @@ class EventRepositoryImplTest {
         assertThat(predicate.toString())
                 .contains("event.endTime")
                 .doesNotContain("event.startTime");
+    }
+
+    @Test
+    @DisplayName("올해 전체 러닝 거리 합산은 예상 러닝 거리 컬럼을 사용한다")
+    void sumDistanceByYearUsesExpectedRunningDistanceKm() {
+        EntityManager entityManager = mock(EntityManager.class);
+        stubSingleResultQuery(entityManager, null);
+        EventRepositoryImpl repository = new EventRepositoryImpl(entityManager);
+
+        repository.sumDistanceByYear(2026);
+
+        String jpql = captureJpql(entityManager);
+        assertThat(jpql)
+                .contains("sum(event.expectedRunningDistanceKm)")
+                .doesNotContain("sum(event.distance)");
+    }
+
+    @Test
+    @DisplayName("개인 참여 수는 종료된 신청 상태 이벤트만 집계한다")
+    void countMyParticipationUsesEndedAppliedEvents() {
+        EntityManager entityManager = mock(EntityManager.class);
+        stubSingleResultQuery(entityManager, null);
+        EventRepositoryImpl repository = new EventRepositoryImpl(entityManager);
+
+        repository.countMyParticipation("member-private");
+
+        String jpql = captureJpql(entityManager);
+        assertThat(jpql)
+                .contains("event.endTime <")
+                .contains("eventForm.status");
+    }
+
+    @Test
+    @DisplayName("개인 참여 거리는 종료된 신청 상태 이벤트의 예상 러닝 거리를 합산한다")
+    void sumMyParticipationDistanceUsesExpectedRunningDistanceKmForEndedAppliedEvents() {
+        EntityManager entityManager = mock(EntityManager.class);
+        stubSingleResultQuery(entityManager, null);
+        EventRepositoryImpl repository = new EventRepositoryImpl(entityManager);
+
+        repository.sumMyParticipationDistance("member-private");
+
+        String jpql = captureJpql(entityManager);
+        assertThat(jpql)
+                .contains("sum(event.expectedRunningDistanceKm)")
+                .contains("event.endTime <")
+                .contains("eventForm.status")
+                .doesNotContain("sum(event.distance)");
+    }
+
+    private Query stubSingleResultQuery(EntityManager entityManager, Object result) {
+        EntityManagerFactory entityManagerFactory = mock(EntityManagerFactory.class);
+        when(entityManagerFactory.getProperties()).thenReturn(Map.of());
+        when(entityManager.getEntityManagerFactory()).thenReturn(entityManagerFactory);
+
+        Query query = mock(Query.class, RETURNS_SELF);
+        when(query.getSingleResult()).thenReturn(result);
+        when(entityManager.createQuery(anyString())).thenReturn(query);
+        return query;
+    }
+
+    private String captureJpql(EntityManager entityManager) {
+        ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(entityManager).createQuery(jpqlCaptor.capture());
+        return jpqlCaptor.getValue();
     }
 }


### PR DESCRIPTION
## 변경 배경
`/api/event/summary`의 러닝 거리 집계가 리뉴얼 필드인 `expectedRunningDistanceKm`가 아니라 기존 `distance` 컬럼을 보고 있어, 이벤트 주최/참여 요약에서 거리가 0으로 표시될 수 있었습니다.

## 주요 변경 사항
- `publicSummary.totalRunningDistanceKm`를 올해 승인 이벤트 전체의 `expectedRunningDistanceKm` 합산으로 변경
- `mySummary.totalParticipationCount`를 로그인 사용자의 APPLIED 신청서 + 승인 + 종료 이벤트 기준으로 변경
- `mySummary.totalRunningDistanceKm`를 같은 종료 참여 이벤트의 `expectedRunningDistanceKm` 합산으로 변경
- QueryDSL JPQL 생성 기준을 검증하는 회귀 테스트 추가

## 검증
- `./gradlew test --rerun-tasks --tests "com.guide.run.event.service.EventGetServiceTest" --tests "com.guide.run.event.entity.repository.EventRepositoryImplTest"` 통과

## 참고
- 전체 `./gradlew test`는 `${TEST_RDS}`가 실제 JDBC URL로 치환되지 않는 기존 테스트 환경 문제로 Spring context 테스트 3개가 실패했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 연간 및 개인 참여 러닝 거리 집계가 예상 러닝 거리를 기준으로 계산되도록 개선했습니다.
  * 개인 참여 통계가 신청 완료된 과거 이벤트만 포함하도록 수정했습니다.

* **테스트**
  * 거리 계산 및 참여 조건을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->