### PR TITLE
fix: 주최자 다가오는 모임 매칭 결과 표시

### DIFF
--- a/run/src/main/java/com/guide/run/event/service/EventGetService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventGetService.java
@@ -195,8 +195,7 @@ public class EventGetService {
                 .sorted(Comparator.comparing(Event::getStartTime))
                 .limit(UPCOMING_MEMBER_LIMIT)
                 .map(event -> {
-                    boolean isOrganizer = privateId.equals(event.getOrganizer());
-                    List<UpcomingEventResponse.PartnerItem> partners = isOrganizer ? List.of() : findPartners(event, member);
+                    List<UpcomingEventResponse.PartnerItem> partners = findPartners(event, member);
                     return UpcomingEventResponse.MemberItem.builder()
                             .id(event.getId())
                             .name(event.getName())

--- a/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventGetServiceTest.java
@@ -1,11 +1,15 @@
 package com.guide.run.event.service;
 
 import com.guide.run.event.entity.Event;
+import com.guide.run.event.entity.EventForm;
 import com.guide.run.event.entity.dto.response.get.AllEvent;
+import com.guide.run.event.entity.dto.response.get.UpcomingEventResponse;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
+import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
+import com.guide.run.partner.entity.matching.Matching;
 import com.guide.run.partner.entity.matching.repository.MatchingRepository;
 import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.entity.type.UserType;
@@ -158,6 +162,51 @@ class EventGetServiceTest {
         var response = eventGetService.getUpcomingEvents("member-private");
 
         assertThat(response.getItems()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("회원 다가오는 이벤트는 주최자여도 신청자 매칭 파트너를 반환한다")
+    void getUpcomingEventsReturnsMatchedPartnersWhenOrganizerAlsoApplied() {
+        User member = User.builder()
+                .privateId("member-private")
+                .role(Role.ROLE_USER)
+                .type(UserType.VI)
+                .build();
+        User guide = User.builder()
+                .privateId("guide-private")
+                .name("가이드 테스트")
+                .type(UserType.GUIDE)
+                .build();
+        Event event = createEvent(
+                1L,
+                EventRecruitStatus.RECRUIT_OPEN,
+                EventTemporalStatusResolver.now().plusDays(2)
+        );
+        EventForm form = EventForm.builder()
+                .eventId(1L)
+                .privateId("member-private")
+                .status(EventFormStatus.APPLIED)
+                .build();
+        Matching matching = Matching.builder()
+                .eventId(1L)
+                .viId("member-private")
+                .guideId("guide-private")
+                .build();
+
+        when(userRepository.findUserByPrivateId("member-private")).thenReturn(Optional.of(member));
+        when(eventFormRepository.findAllByPrivateId("member-private")).thenReturn(List.of(form));
+        when(eventRepository.findAllById(any())).thenReturn(List.of(event));
+        when(eventRepository.findAllByOrganizer("member-private")).thenReturn(List.of(event));
+        when(matchingRepository.findAllByEventIdAndViId(1L, "member-private")).thenReturn(List.of(matching));
+        when(userRepository.findAllById(List.of("guide-private"))).thenReturn(List.of(guide));
+
+        var response = eventGetService.getUpcomingEvents("member-private");
+        List<?> items = response.getItems();
+        UpcomingEventResponse.MemberItem item = (UpcomingEventResponse.MemberItem) items.get(0);
+
+        assertThat(item.getMyPartner()).hasSize(1);
+        assertThat(item.getMyPartner().get(0).getName()).isEqualTo("가이드 테스트");
+        assertThat(item.getMyPartner().get(0).getType()).isEqualTo(UserType.GUIDE);
     }
 
     private Event createEvent(Long id, EventRecruitStatus recruitStatus, LocalDateTime startTime) {


### PR DESCRIPTION
## 변경 배경
회원이 본인이 주최한 이벤트에도 신청자로 참여하고 매칭까지 완료된 경우, 다가오는 러닝 모임 응답에서 매칭 파트너가 비어 내려가 매칭 전 상태처럼 표시되는 문제가 있었습니다.

## 주요 변경 사항
- 다가오는 러닝 모임 조회 시 주최자 여부와 관계없이 신청자의 매칭 파트너를 조회하도록 변경
- 주최자이면서 신청자인 회원의 매칭 파트너가 응답에 포함되는 회귀 테스트 추가

## 검증
- `./gradlew test --rerun-tasks --tests "com.guide.run.event.service.EventGetServiceTest"` 통과