### PR TITLE
fix: 활동 이벤트에서 취소 신청 제외

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.guide.run.event.entity.type.EventStatus;
 import com.guide.run.event.entity.type.EventType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 
@@ -543,19 +544,22 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
 
     private BooleanBuilder activityRelationCond(String privateId, String relation) {
         if ("PARTICIPATED".equals(relation)) {
-            return new BooleanBuilder(
-                    JPAExpressions.selectFrom(eventForm)
-                            .where(eventForm.eventId.eq(event.id).and(eventForm.privateId.eq(privateId)))
-                            .exists());
+            return new BooleanBuilder(activeParticipationExists(privateId));
         } else if ("HOSTED".equals(relation)) {
             return new BooleanBuilder(event.organizer.eq(privateId));
         } else {
             return new BooleanBuilder(
                     event.organizer.eq(privateId)
-                            .or(JPAExpressions.selectFrom(eventForm)
-                                    .where(eventForm.eventId.eq(event.id).and(eventForm.privateId.eq(privateId)))
-                                    .exists()));
+                            .or(activeParticipationExists(privateId)));
         }
+    }
+
+    private BooleanExpression activeParticipationExists(String privateId) {
+        return JPAExpressions.selectFrom(eventForm)
+                .where(eventForm.eventId.eq(event.id)
+                        .and(eventForm.privateId.eq(privateId))
+                        .and(eventForm.status.eq(APPLIED)))
+                .exists();
     }
 
     @Override

--- a/run/src/test/java/com/guide/run/event/entity/repository/EventRepositoryImplTest.java
+++ b/run/src/test/java/com/guide/run/event/entity/repository/EventRepositoryImplTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,6 +82,36 @@ class EventRepositoryImplTest {
                 .doesNotContain("sum(event.distance)");
     }
 
+    @Test
+    @DisplayName("참여 활동 목록은 신청 상태 이벤트만 조회한다")
+    void activityParticipatedEventsUseAppliedForms() {
+        EntityManager entityManager = mock(EntityManager.class);
+        stubSingleResultQuery(entityManager, null);
+        EventRepositoryImpl repository = new EventRepositoryImpl(entityManager);
+
+        repository.findActivityEvents("member-private", null, "PARTICIPATED", 0, 10);
+
+        String jpql = captureJpql(entityManager);
+        assertThat(jpql)
+                .contains("eventForm.status")
+                .contains("exists");
+    }
+
+    @Test
+    @DisplayName("전체 활동 목록도 신청 상태 이벤트만 조회한다")
+    void totalActivityEventsUseAppliedForms() {
+        EntityManager entityManager = mock(EntityManager.class);
+        stubSingleResultQuery(entityManager, null);
+        EventRepositoryImpl repository = new EventRepositoryImpl(entityManager);
+
+        repository.findActivityEvents("member-private", null, "TOTAL", 0, 10);
+
+        String jpql = captureJpql(entityManager);
+        assertThat(jpql)
+                .contains("eventForm.status")
+                .contains("exists");
+    }
+
     private Query stubSingleResultQuery(EntityManager entityManager, Object result) {
         EntityManagerFactory entityManagerFactory = mock(EntityManagerFactory.class);
         when(entityManagerFactory.getProperties()).thenReturn(Map.of());
@@ -88,6 +119,7 @@ class EventRepositoryImplTest {
 
         Query query = mock(Query.class, RETURNS_SELF);
         when(query.getSingleResult()).thenReturn(result);
+        when(query.getResultList()).thenReturn(List.of());
         when(entityManager.createQuery(anyString())).thenReturn(query);
         return query;
     }


### PR DESCRIPTION
## 변경 사항
- 활동 이벤트의 `PARTICIPATED` 조회에서 `APPLIED` 신청서만 참여로 인정합니다.
- 기본 `TOTAL` 조회에도 동일한 참여 기준을 적용합니다.
- 취소 신청이 활동 이벤트 목록에 다시 포함되지 않도록 저장소 테스트를 추가했습니다.

## 원인
활동 이벤트 목록은 신청서 존재 여부만 확인해 취소된 신청서(`CANCELED`)가 있어도 참여 이벤트로 노출됐습니다.

## 검증
- `./gradlew test --tests com.guide.run.event.entity.repository.EventRepositoryImplTest`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 활동 이벤트 조회 시 참여 상태가 올바르게 반영되도록 조건을 개선했습니다.
  * 참여 활동 및 전체 활동 조회에서 유효한 참여 기록이 있는 이벤트만 정확히 표시됩니다.

* **테스트**
  * 참여 활동과 전체 활동 조회 조건에 대한 검증을 추가해 검색 결과의 정확성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->