### PR TITLE
fix: BE 에러 메시지 한글화

### DIFF
--- a/run/src/main/java/com/guide/run/global/jwt/JwtExceptionFilter.java
+++ b/run/src/main/java/com/guide/run/global/jwt/JwtExceptionFilter.java
@@ -29,7 +29,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         try{
             filterChain.doFilter(request, response);
         } catch (NotValidAccessTokenException e){
-            sendError(request, response, "0100", "유효하지 않은 accessToken 입니다.");
+            sendError(request, response, "0100", "유효하지 않은 액세스토큰입니다.");
             log.error("유효하지 않은 엑세스 토큰");
             return;
         }catch (NotExistAuthorizationException e){

--- a/run/src/main/resources/i18n/exception_ko.yml
+++ b/run/src/main/resources/i18n/exception_ko.yml
@@ -11,17 +11,17 @@ notValidPassword:
   msg: "비밀번호가 일치하지 않습니다"
 notValidAccessToken:
   code: "0100"
-  msg: "유효하지 않은 accessToken 입니다."
+  msg: "유효하지 않은 액세스토큰입니다."
 notExistAuthorization:
   code: "0101"
   msg: "인증할 수 있는 사용자 데이터가 존재하지 않습니다"
 notValidRefreshToken:
   code: "0104"
-  msg: "유효하지 않은 refreshToken 입니다."
+  msg: "유효하지 않은 리프레시토큰입니다."
 
 duplicatedUserId:
   code: "1001"
-  msg: "이미 존재하는 id 입니다"
+  msg: "이미 존재하는 아이디입니다"
 notValidPasswordCombination:
   code: "1002"
   msg: "비밀번호의 조합이 유효하지 않습니다."
@@ -137,19 +137,19 @@ notExistForm:
 
 notAuthorityVi:
   code: "3100"
-  msg: "Vi 권한이 없습니다."
+  msg: "시각장애러너 권한이 없습니다."
 
 notAuthorityGuide:
   code: "4100"
-  msg: "Guide 권한이 없습니다."
+  msg: "가이드러너 권한이 없습니다."
 
 notAuthorityAdmin:
   code: "5100"
-  msg: "Admin 권한이 없습니다."
+  msg: "운영진 권한이 없습니다."
 
 notAuthorityCoach:
   code: "6100"
-  msg: "Coach 권한이 없습니다."
+  msg: "운영진 권한이 없습니다."
 
 notValidImgFormat:
   code: "7001"
@@ -157,6 +157,5 @@ notValidImgFormat:
 exceededImgSize:
   code: "7002"
   msg: "최대 업로드 용량을 초과했습니다."
-
 
 


### PR DESCRIPTION
## 변경 배경
BE 에러 응답 메시지에 영어와 한글이 혼용된 표현이 있어 사용자 노출 문구를 한글 표현으로 통일했습니다.

## 주요 변경 사항
- accessToken -> 액세스토큰
- refreshToken -> 리프레시토큰
- id -> 아이디
- Vi -> 시각장애러너
- Guide -> 가이드러너
- Admin, Coach -> 운영진
- JwtExceptionFilter의 accessToken 하드코딩 메시지도 동일하게 변경

## 검증
- ./gradlew compileJava --rerun-tasks 통과
- 관련 예외 테스트 묶음 통과
  - JwtExceptionFilterTest
  - AuthAuthorizeExceptionAdviceTest
  - UserDtoExceptionAdviceTest
  - ViAuthorizeExceptionAdviceTest
  - GuideAuthorizeExceptionAdviceTest
  - AdminAuthorizeExceptionAdviceTest
  - CoachAuthorizeExceptionAdviceTest
- BE i18n 에러 메시지 한글+영문 혼용 개수 0개 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 액세스 토큰 및 리프레시 토큰 관련 오류 메시지를 자연스러운 한국어로 개선했습니다.
  * 사용자 ID 중복 안내 문구를 명확한 표현으로 수정했습니다.
  * 권한 부족 오류 메시지를 역할에 맞는 한국어 표현으로 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->