### PR TITLE
feat: 훈련 참여 및 안전 면책 동의 추가

### DIFF
--- a/run/src/main/java/com/guide/run/admin/dto/response/GuideApplyResponse.java
+++ b/run/src/main/java/com/guide/run/admin/dto/response/GuideApplyResponse.java
@@ -37,5 +37,6 @@ public class GuideApplyResponse {
 
     private boolean privacy;
     private boolean portraitRights;
+    private boolean trainingSafety;
 
 }

--- a/run/src/main/java/com/guide/run/admin/dto/response/ViApplyResponse.java
+++ b/run/src/main/java/com/guide/run/admin/dto/response/ViApplyResponse.java
@@ -34,5 +34,6 @@ public class ViApplyResponse {
 
     private boolean privacy;
     private boolean portraitRights;
+    private boolean trainingSafety;
 
 }

--- a/run/src/main/java/com/guide/run/admin/service/AdminUserService.java
+++ b/run/src/main/java/com/guide/run/admin/service/AdminUserService.java
@@ -72,6 +72,7 @@ public class AdminUserService {
                 .motive(archiveData.getMotive())
                 .privacy(archiveData.isPrivacy())
                 .portraitRights(archiveData.isPortraitRights())
+                .trainingSafety(archiveData.isTrainingSafety())
                 .build();
      return response;
     }
@@ -99,6 +100,7 @@ public class AdminUserService {
                 .motive(archiveData.getMotive())
 
                 .privacy(archiveData.isPrivacy())
+                .trainingSafety(archiveData.isTrainingSafety())
                 .snsId(user.getSnsId())
                 .build();
         return response;

--- a/run/src/main/java/com/guide/run/user/controller/SignupInfoController.java
+++ b/run/src/main/java/com/guide/run/user/controller/SignupInfoController.java
@@ -7,6 +7,7 @@ import com.guide.run.user.dto.PersonalInfoDto;
 import com.guide.run.user.dto.ViRunningInfoDto;
 import com.guide.run.user.dto.request.AccountIdDto;
 import com.guide.run.user.dto.request.SetAccountRequest;
+import com.guide.run.user.dto.request.TrainingSafetyAgreementRequest;
 import com.guide.run.user.dto.request.UpdatePersonalInfoRequest;
 import com.guide.run.user.dto.request.UpdateRunningInfoRequest;
 import com.guide.run.user.dto.request.UserBirthDatePatchRequest;
@@ -79,6 +80,13 @@ public class SignupInfoController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "내 약관 동의 조회", description = "로그인한 사용자의 개인정보/초상권/훈련 안전 면책 동의 상태를 조회합니다.")
+    @GetMapping("/user/permission")
+    public ResponseEntity<PermissionDto> getMyPermission(HttpServletRequest httpServletRequest) {
+        String privateId = jwtProvider.extractUserId(httpServletRequest);
+        return ResponseEntity.ok(signupInfoService.getMyPermission(privateId));
+    }
+
     //약관 동의 수정
     @Operation(summary = "약관 동의 수정", description = "정보 수정 화면에서 개인정보/초상권 동의 여부를 저장합니다.")
     @PatchMapping("/user/permission")
@@ -88,6 +96,15 @@ public class SignupInfoController {
         PermissionDto response = signupInfoService.editPermission(privateId, request);
 
         return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "훈련 참여 및 안전 면책 동의", description = "기존 회원이 바텀시트에서 필수 훈련 안전 면책 약관에 동의합니다.")
+    @PatchMapping("/user/permission/training-safety")
+    public ResponseEntity<PermissionDto> agreeTrainingSafety(
+            @RequestBody @Valid TrainingSafetyAgreementRequest request,
+            HttpServletRequest httpServletRequest) {
+        String privateId = jwtProvider.extractUserId(httpServletRequest);
+        return ResponseEntity.ok(signupInfoService.agreeTrainingSafety(privateId));
     }
 
     //인적사항 조회

--- a/run/src/main/java/com/guide/run/user/dto/GuideSignupDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/GuideSignupDto.java
@@ -59,6 +59,8 @@ public class GuideSignupDto {
     private boolean privacy;
     @NotNull
     private boolean portraitRights;
+    @NotNull
+    private boolean trainingSafety;
 
     private String id1365;
     private String birth;

--- a/run/src/main/java/com/guide/run/user/dto/PermissionDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/PermissionDto.java
@@ -14,4 +14,6 @@ public class PermissionDto {
     private boolean privacy;
     @Schema(description = "초상권 활용 동의", example = "true")
     private boolean portraitRights;
+    @Schema(description = "훈련 참여 및 안전 면책 동의", example = "true")
+    private boolean trainingSafety;
 }

--- a/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
@@ -27,14 +27,8 @@ public class PersonalInfoDto {
     private Boolean isOpenSns;
     private String id1365;
     private String birth;
-    @Schema(description = "훈련 참여 및 안전 면책 동의 여부", example = "true")
-    private boolean trainingSafety;
 
     public static PersonalInfoDto userToInfoDto(User user){
-        return userToInfoDto(user, false);
-    }
-
-    public static PersonalInfoDto userToInfoDto(User user, boolean trainingSafety){
         return PersonalInfoDto.builder()
                 .role(user.getRole().getValue().substring(5))
                 .type(user.getType().getValue())
@@ -47,7 +41,6 @@ public class PersonalInfoDto {
                 .isOpenNumber(user.getIsOpenNumber())
                 .id1365(user.getId1365())
                 .birth(user.getBirth())
-                .trainingSafety(trainingSafety)
                 .build();
     }
 }

--- a/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/PersonalInfoDto.java
@@ -27,8 +27,14 @@ public class PersonalInfoDto {
     private Boolean isOpenSns;
     private String id1365;
     private String birth;
+    @Schema(description = "훈련 참여 및 안전 면책 동의 여부", example = "true")
+    private boolean trainingSafety;
 
     public static PersonalInfoDto userToInfoDto(User user){
+        return userToInfoDto(user, false);
+    }
+
+    public static PersonalInfoDto userToInfoDto(User user, boolean trainingSafety){
         return PersonalInfoDto.builder()
                 .role(user.getRole().getValue().substring(5))
                 .type(user.getType().getValue())
@@ -41,6 +47,7 @@ public class PersonalInfoDto {
                 .isOpenNumber(user.getIsOpenNumber())
                 .id1365(user.getId1365())
                 .birth(user.getBirth())
+                .trainingSafety(trainingSafety)
                 .build();
     }
 }

--- a/run/src/main/java/com/guide/run/user/dto/ViSignupDto.java
+++ b/run/src/main/java/com/guide/run/user/dto/ViSignupDto.java
@@ -57,6 +57,8 @@ public class ViSignupDto {
     private boolean privacy;
     @NotNull
     private boolean portraitRights;
+    @NotNull
+    private boolean trainingSafety;
 
     private String id1365;
     private String birth;

--- a/run/src/main/java/com/guide/run/user/dto/request/SignupRequest.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/SignupRequest.java
@@ -70,6 +70,9 @@ public class SignupRequest {
 
         @Schema(description = "초상권 활용 동의 (true 필수)", example = "true")
         private boolean portraitRights;
+
+        @Schema(description = "훈련 참여 및 안전 면책 동의 (true 필수)", example = "true")
+        private boolean trainingSafety;
     }
 
     @Getter

--- a/run/src/main/java/com/guide/run/user/dto/request/TrainingSafetyAgreementRequest.java
+++ b/run/src/main/java/com/guide/run/user/dto/request/TrainingSafetyAgreementRequest.java
@@ -1,0 +1,20 @@
+package com.guide.run.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "훈련 참여 및 안전 면책 동의 요청")
+public class TrainingSafetyAgreementRequest {
+
+    @NotNull
+    @AssertTrue
+    @Schema(description = "훈련 참여 및 안전 면책 동의 여부 (true 필수)", example = "true")
+    private Boolean trainingSafety;
+}

--- a/run/src/main/java/com/guide/run/user/dto/response/UserInfoAll/GuideInfoAllResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/UserInfoAll/GuideInfoAllResponse.java
@@ -41,4 +41,5 @@ public class GuideInfoAllResponse {
     //약관동의
     private boolean privacy;
     private boolean portraitRights;
+    private boolean trainingSafety;
 }

--- a/run/src/main/java/com/guide/run/user/dto/response/UserInfoAll/ViInfoAllResponse.java
+++ b/run/src/main/java/com/guide/run/user/dto/response/UserInfoAll/ViInfoAllResponse.java
@@ -38,4 +38,5 @@ public class ViInfoAllResponse {
     //약관동의
     private boolean privacy;
     private boolean portraitRights;
+    private boolean trainingSafety;
 }

--- a/run/src/main/java/com/guide/run/user/entity/ArchiveData.java
+++ b/run/src/main/java/com/guide/run/user/entity/ArchiveData.java
@@ -28,6 +28,7 @@ public class ArchiveData {
     private String hopePrefs;
     private boolean privacy;
     private boolean portraitRights;
+    private boolean trainingSafety;
 
 
 
@@ -37,6 +38,10 @@ public class ArchiveData {
     ){
         this.privacy = privacy;
         this.portraitRights = portraitRights;
+    }
+
+    public void agreeTrainingSafety() {
+        this.trainingSafety = true;
     }
 
     public void editRunningInfo(

--- a/run/src/main/java/com/guide/run/user/service/GetUserInfoService.java
+++ b/run/src/main/java/com/guide/run/user/service/GetUserInfoService.java
@@ -63,6 +63,7 @@ public class GetUserInfoService {
 
                                 .portraitRights(archiveData.isPortraitRights())
                                 .privacy(archiveData.isPrivacy())
+                                .trainingSafety(archiveData.isTrainingSafety())
                                 .build();
 
                         viResponse.add(viInfoAllResponse);
@@ -96,6 +97,7 @@ public class GetUserInfoService {
 
                                 .portraitRights(archiveData.isPortraitRights())
                                 .privacy(archiveData.isPrivacy())
+                                .trainingSafety(archiveData.isTrainingSafety())
 
                                 .build();
 

--- a/run/src/main/java/com/guide/run/user/service/GuideService.java
+++ b/run/src/main/java/com/guide/run/user/service/GuideService.java
@@ -1,6 +1,7 @@
 package com.guide.run.user.service;
 
 import com.guide.run.global.exception.user.authorize.ExistUserException;
+import com.guide.run.global.exception.user.dto.NotAgreeTermException;
 import com.guide.run.global.exception.user.resource.NotExistUserException;
 import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.user.dto.GuideSignupDto;
@@ -35,6 +36,12 @@ public class GuideService {
 
     @Transactional
     public SignupResponse guideSignup(String privateId, GuideSignupDto guideSignupDto){
+        if (!guideSignupDto.isPrivacy()
+                || !guideSignupDto.isPortraitRights()
+                || !guideSignupDto.isTrainingSafety()) {
+            throw new NotAgreeTermException();
+        }
+
         User user = userRepository.findById(privateId).orElse(null);
         if(user!=null && !user.getRole().equals(Role.ROLE_NEW)) {
             //log.info("에러발생");
@@ -87,6 +94,7 @@ public class GuideService {
                     .privacy(guideSignupDto.isPrivacy())
                     .hopePrefs(guideSignupDto.getHopePrefs())
                     .portraitRights(guideSignupDto.isPortraitRights())
+                    .trainingSafety(guideSignupDto.isTrainingSafety())
                     .runningPlace(guideSignupDto.getRunningPlace())
                     .build();
 

--- a/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
+++ b/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
@@ -237,7 +237,10 @@ public class SignupInfoService {
         if(viewer.getRole()!= Role.ROLE_ADMIN && !user.getPrivateId().equals(privateId)){
             throw new UnauthorizedUserException();
         }
-        return PersonalInfoDto.userToInfoDto(user);
+        ArchiveData archiveData = archiveDataRepository.findById(user.getPrivateId()).orElseThrow(
+                NotExistUserException::new
+        );
+        return PersonalInfoDto.userToInfoDto(user, archiveData.isTrainingSafety());
     }
     //개인 정보 수정
     @Transactional

--- a/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
+++ b/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
@@ -237,10 +237,7 @@ public class SignupInfoService {
         if(viewer.getRole()!= Role.ROLE_ADMIN && !user.getPrivateId().equals(privateId)){
             throw new UnauthorizedUserException();
         }
-        ArchiveData archiveData = archiveDataRepository.findById(user.getPrivateId()).orElseThrow(
-                NotExistUserException::new
-        );
-        return PersonalInfoDto.userToInfoDto(user, archiveData.isTrainingSafety());
+        return PersonalInfoDto.userToInfoDto(user);
     }
     //개인 정보 수정
     @Transactional

--- a/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
+++ b/run/src/main/java/com/guide/run/user/service/SignupInfoService.java
@@ -70,7 +70,18 @@ public class SignupInfoService {
         return PermissionDto.builder()
                 .privacy(archiveData.isPrivacy())
                 .portraitRights(archiveData.isPortraitRights())
+                .trainingSafety(archiveData.isTrainingSafety())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public PermissionDto getMyPermission(String privateId) {
+        userRepository.findById(privateId).orElseThrow(NotExistUserException::new);
+        ArchiveData archiveData = archiveDataRepository.findById(privateId).orElseThrow(
+                NotExistUserException::new
+        );
+
+        return toPermissionDto(archiveData);
     }
 
     @Transactional
@@ -87,6 +98,25 @@ public class SignupInfoService {
         return PermissionDto.builder()
                 .privacy(archiveData.isPrivacy())
                 .portraitRights(archiveData.isPortraitRights())
+                .trainingSafety(archiveData.isTrainingSafety())
+                .build();
+    }
+
+    @Transactional
+    public PermissionDto agreeTrainingSafety(String privateId) {
+        ArchiveData archiveData = archiveDataRepository.findById(privateId).orElseThrow(
+                NotExistUserException::new
+        );
+
+        archiveData.agreeTrainingSafety();
+        return toPermissionDto(archiveData);
+    }
+
+    private PermissionDto toPermissionDto(ArchiveData archiveData) {
+        return PermissionDto.builder()
+                .privacy(archiveData.isPrivacy())
+                .portraitRights(archiveData.isPortraitRights())
+                .trainingSafety(archiveData.isTrainingSafety())
                 .build();
     }
 

--- a/run/src/main/java/com/guide/run/user/service/SignupService.java
+++ b/run/src/main/java/com/guide/run/user/service/SignupService.java
@@ -43,8 +43,8 @@ public class SignupService {
     public IntegratedSignupResponse signup(String privateId, SignupRequest request) {
         SignupRequest.Common common = request.getCommon();
 
-        // 약관 동의 검증: 둘 다 true 여야 함
-        if (!common.isPrivacy() || !common.isPortraitRights()) {
+        // 필수 약관은 모두 true 여야 함
+        if (!common.isPrivacy() || !common.isPortraitRights() || !common.isTrainingSafety()) {
             throw new NotAgreeTermException();
         }
 
@@ -103,6 +103,7 @@ public class SignupService {
                     .privacy(common.isPrivacy())
                     .hopePrefs(viReq.getHopePrefs())
                     .portraitRights(common.isPortraitRights())
+                    .trainingSafety(common.isTrainingSafety())
                     .runningPlace(viReq.getRunningPlace())
                     .build();
         } else if (UserType.GUIDE.equals(type)) {
@@ -129,6 +130,7 @@ public class SignupService {
                     .privacy(common.isPrivacy())
                     .hopePrefs(guideReq.getHopePrefs())
                     .portraitRights(common.isPortraitRights())
+                    .trainingSafety(common.isTrainingSafety())
                     .runningPlace(guideReq.getRunningPlace())
                     .build();
         } else {

--- a/run/src/main/java/com/guide/run/user/service/ViService.java
+++ b/run/src/main/java/com/guide/run/user/service/ViService.java
@@ -1,6 +1,7 @@
 package com.guide.run.user.service;
 
 import com.guide.run.global.exception.user.authorize.ExistUserException;
+import com.guide.run.global.exception.user.dto.NotAgreeTermException;
 import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.user.dto.ViSignupDto;
 import com.guide.run.user.dto.response.SignupResponse;
@@ -34,6 +35,12 @@ public class ViService {
 
     @Transactional
     public SignupResponse viSignup(String privateId, ViSignupDto viSignupDto){
+        if (!viSignupDto.isPrivacy()
+                || !viSignupDto.isPortraitRights()
+                || !viSignupDto.isTrainingSafety()) {
+            throw new NotAgreeTermException();
+        }
+
         User user = userRepository.findById(privateId).orElse(null);
         log.info(privateId);
         if(user!=null && !user.getRole().equals(Role.ROLE_NEW)) {
@@ -80,6 +87,7 @@ public class ViService {
                     .privacy(viSignupDto.isPrivacy())
                     .hopePrefs(viSignupDto.getHopePrefs())
                     .portraitRights(viSignupDto.isPortraitRights())
+                    .trainingSafety(viSignupDto.isTrainingSafety())
                     .runningPlace(viSignupDto.getRunningPlace())
                     .build();
 

--- a/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
+++ b/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
@@ -5,7 +5,6 @@ import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.global.service.ResponseService;
 import com.guide.run.user.controller.SignupInfoController;
 import com.guide.run.user.dto.PermissionDto;
-import com.guide.run.user.dto.PersonalInfoDto;
 import com.guide.run.user.dto.response.MyPageResponse;
 import com.guide.run.user.dto.response.SetAccountResponse;
 import com.guide.run.user.dto.response.UpdatePersonalInfoResponse;
@@ -161,21 +160,6 @@ class SecurityConfigMypageAuthTest {
                                 }
                                 """))
                 .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("개인정보 조회 응답에 훈련 안전 면책 동의 상태를 반환한다")
-    void personalInfoReturnsTrainingSafety() throws Exception {
-        authenticateWaitUser();
-        when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
-        when(signupInfoService.getPersonalInfo(PRIVATE_ID, "u1")).thenReturn(PersonalInfoDto.builder()
-                .trainingSafety(false)
-                .build());
-
-        mockMvc.perform(get("/api/user/personal/u1")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.trainingSafety").value(false));
     }
 
     @Test

--- a/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
+++ b/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
@@ -5,6 +5,7 @@ import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.global.service.ResponseService;
 import com.guide.run.user.controller.SignupInfoController;
 import com.guide.run.user.dto.PermissionDto;
+import com.guide.run.user.dto.PersonalInfoDto;
 import com.guide.run.user.dto.response.MyPageResponse;
 import com.guide.run.user.dto.response.SetAccountResponse;
 import com.guide.run.user.dto.response.UpdatePersonalInfoResponse;
@@ -160,6 +161,21 @@ class SecurityConfigMypageAuthTest {
                                 }
                                 """))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("개인정보 조회 응답에 훈련 안전 면책 동의 상태를 반환한다")
+    void personalInfoReturnsTrainingSafety() throws Exception {
+        authenticateWaitUser();
+        when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
+        when(signupInfoService.getPersonalInfo(PRIVATE_ID, "u1")).thenReturn(PersonalInfoDto.builder()
+                .trainingSafety(false)
+                .build());
+
+        mockMvc.perform(get("/api/user/personal/u1")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.trainingSafety").value(false));
     }
 
     @Test

--- a/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
+++ b/run/src/test/java/com/guide/run/global/security/config/SecurityConfigMypageAuthTest.java
@@ -4,6 +4,7 @@ import com.guide.run.global.exception.ErrorResponseFactory;
 import com.guide.run.global.jwt.JwtProvider;
 import com.guide.run.global.service.ResponseService;
 import com.guide.run.user.controller.SignupInfoController;
+import com.guide.run.user.dto.PermissionDto;
 import com.guide.run.user.dto.response.MyPageResponse;
 import com.guide.run.user.dto.response.SetAccountResponse;
 import com.guide.run.user.dto.response.UpdatePersonalInfoResponse;
@@ -179,6 +180,62 @@ class SecurityConfigMypageAuthTest {
                                 }
                                 """))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("ROLE_WAIT 회원은 자신의 약관 동의 상태를 조회할 수 있다")
+    void waitUserCanGetOwnPermission() throws Exception {
+        authenticateWaitUser();
+        when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
+        when(signupInfoService.getMyPermission(PRIVATE_ID)).thenReturn(PermissionDto.builder()
+                .privacy(true)
+                .portraitRights(true)
+                .trainingSafety(false)
+                .build());
+
+        mockMvc.perform(get("/api/user/permission")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.trainingSafety").value(false));
+    }
+
+    @Test
+    @DisplayName("ROLE_WAIT 회원은 훈련 참여 및 안전 면책 약관에 동의할 수 있다")
+    void waitUserCanAgreeTrainingSafety() throws Exception {
+        authenticateWaitUser();
+        when(jwtProvider.extractUserId(any(HttpServletRequest.class))).thenReturn(PRIVATE_ID);
+        when(signupInfoService.agreeTrainingSafety(PRIVATE_ID)).thenReturn(PermissionDto.builder()
+                .privacy(true)
+                .portraitRights(true)
+                .trainingSafety(true)
+                .build());
+
+        mockMvc.perform(patch("/api/user/permission/training-safety")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "trainingSafety": true
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.trainingSafety").value(true));
+    }
+
+    @Test
+    @DisplayName("훈련 참여 및 안전 면책 약관에 동의하지 않은 요청은 400을 반환한다")
+    void trainingSafetyMustBeTrue() throws Exception {
+        authenticateWaitUser();
+
+        mockMvc.perform(patch("/api/user/permission/training-safety")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + WAIT_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "trainingSafety": false
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
     }
 
     private void authenticateWaitUser() {

--- a/run/src/test/java/com/guide/run/user/service/SignupInfoServiceTest.java
+++ b/run/src/test/java/com/guide/run/user/service/SignupInfoServiceTest.java
@@ -6,6 +6,7 @@ import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.event.entity.type.EventType;
+import com.guide.run.user.dto.PermissionDto;
 import com.guide.run.user.dto.request.UpdateRunningInfoRequest;
 import com.guide.run.user.dto.response.MyPageResponse;
 import com.guide.run.user.dto.response.UpdateRunningInfoResponse;
@@ -45,6 +46,45 @@ class SignupInfoServiceTest {
     @InjectMocks private SignupInfoService signupInfoService;
 
     private static final String PRIVATE_ID = "kakao_1";
+
+    @Test
+    @DisplayName("내 약관 동의 조회 시 훈련 안전 면책 동의 상태를 함께 반환한다")
+    void getMyPermissionReturnsTrainingSafety() {
+        User user = User.builder().userId("u1").privateId(PRIVATE_ID).build();
+        ArchiveData archiveData = ArchiveData.builder()
+                .privateId(PRIVATE_ID)
+                .privacy(true)
+                .portraitRights(true)
+                .trainingSafety(false)
+                .build();
+        when(userRepository.findById(PRIVATE_ID)).thenReturn(Optional.of(user));
+        when(archiveDataRepository.findById(PRIVATE_ID)).thenReturn(Optional.of(archiveData));
+
+        PermissionDto response = signupInfoService.getMyPermission(PRIVATE_ID);
+
+        assertThat(response.isPrivacy()).isTrue();
+        assertThat(response.isPortraitRights()).isTrue();
+        assertThat(response.isTrainingSafety()).isFalse();
+    }
+
+    @Test
+    @DisplayName("기존 회원의 훈련 안전 면책 동의는 다른 약관 값을 변경하지 않고 true로 저장한다")
+    void agreeTrainingSafetyPreservesExistingPermissions() {
+        ArchiveData archiveData = ArchiveData.builder()
+                .privateId(PRIVATE_ID)
+                .privacy(true)
+                .portraitRights(false)
+                .trainingSafety(false)
+                .build();
+        when(archiveDataRepository.findById(PRIVATE_ID)).thenReturn(Optional.of(archiveData));
+
+        PermissionDto response = signupInfoService.agreeTrainingSafety(PRIVATE_ID);
+
+        assertThat(response.isPrivacy()).isTrue();
+        assertThat(response.isPortraitRights()).isFalse();
+        assertThat(response.isTrainingSafety()).isTrue();
+        assertThat(archiveData.isTrainingSafety()).isTrue();
+    }
 
     @Test
     @DisplayName("ArchiveData가 없는 사용자도 러닝 정보 수정 시 ArchiveData를 새로 생성하여 저장한다 (500 방지)")

--- a/run/src/test/java/com/guide/run/user/service/SignupInfoServiceTest.java
+++ b/run/src/test/java/com/guide/run/user/service/SignupInfoServiceTest.java
@@ -7,10 +7,12 @@ import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.event.entity.type.EventType;
 import com.guide.run.user.dto.PermissionDto;
+import com.guide.run.user.dto.PersonalInfoDto;
 import com.guide.run.user.dto.request.UpdateRunningInfoRequest;
 import com.guide.run.user.dto.response.MyPageResponse;
 import com.guide.run.user.dto.response.UpdateRunningInfoResponse;
 import com.guide.run.user.entity.ArchiveData;
+import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.ArchiveDataRepository;
@@ -46,6 +48,28 @@ class SignupInfoServiceTest {
     @InjectMocks private SignupInfoService signupInfoService;
 
     private static final String PRIVATE_ID = "kakao_1";
+
+    @Test
+    @DisplayName("개인정보 조회 응답에 훈련 안전 면책 동의 상태를 포함한다")
+    void getPersonalInfoReturnsTrainingSafety() {
+        User user = User.builder()
+                .userId("u1")
+                .privateId(PRIVATE_ID)
+                .role(Role.ROLE_USER)
+                .type(UserType.GUIDE)
+                .build();
+        ArchiveData archiveData = ArchiveData.builder()
+                .privateId(PRIVATE_ID)
+                .trainingSafety(true)
+                .build();
+        when(userRepository.findUserByUserId("u1")).thenReturn(Optional.of(user));
+        when(userRepository.findById(PRIVATE_ID)).thenReturn(Optional.of(user));
+        when(archiveDataRepository.findById(PRIVATE_ID)).thenReturn(Optional.of(archiveData));
+
+        PersonalInfoDto response = signupInfoService.getPersonalInfo(PRIVATE_ID, "u1");
+
+        assertThat(response.isTrainingSafety()).isTrue();
+    }
 
     @Test
     @DisplayName("내 약관 동의 조회 시 훈련 안전 면책 동의 상태를 함께 반환한다")

--- a/run/src/test/java/com/guide/run/user/service/SignupInfoServiceTest.java
+++ b/run/src/test/java/com/guide/run/user/service/SignupInfoServiceTest.java
@@ -7,12 +7,10 @@ import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.event.entity.type.EventType;
 import com.guide.run.user.dto.PermissionDto;
-import com.guide.run.user.dto.PersonalInfoDto;
 import com.guide.run.user.dto.request.UpdateRunningInfoRequest;
 import com.guide.run.user.dto.response.MyPageResponse;
 import com.guide.run.user.dto.response.UpdateRunningInfoResponse;
 import com.guide.run.user.entity.ArchiveData;
-import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.ArchiveDataRepository;
@@ -48,28 +46,6 @@ class SignupInfoServiceTest {
     @InjectMocks private SignupInfoService signupInfoService;
 
     private static final String PRIVATE_ID = "kakao_1";
-
-    @Test
-    @DisplayName("개인정보 조회 응답에 훈련 안전 면책 동의 상태를 포함한다")
-    void getPersonalInfoReturnsTrainingSafety() {
-        User user = User.builder()
-                .userId("u1")
-                .privateId(PRIVATE_ID)
-                .role(Role.ROLE_USER)
-                .type(UserType.GUIDE)
-                .build();
-        ArchiveData archiveData = ArchiveData.builder()
-                .privateId(PRIVATE_ID)
-                .trainingSafety(true)
-                .build();
-        when(userRepository.findUserByUserId("u1")).thenReturn(Optional.of(user));
-        when(userRepository.findById(PRIVATE_ID)).thenReturn(Optional.of(user));
-        when(archiveDataRepository.findById(PRIVATE_ID)).thenReturn(Optional.of(archiveData));
-
-        PersonalInfoDto response = signupInfoService.getPersonalInfo(PRIVATE_ID, "u1");
-
-        assertThat(response.isTrainingSafety()).isTrue();
-    }
 
     @Test
     @DisplayName("내 약관 동의 조회 시 훈련 안전 면책 동의 상태를 함께 반환한다")

--- a/run/src/test/java/com/guide/run/user/service/SignupServiceTest.java
+++ b/run/src/test/java/com/guide/run/user/service/SignupServiceTest.java
@@ -49,24 +49,24 @@ class SignupServiceTest {
 
     private static final String PRIVATE_ID = "kakao_1";
 
-    private SignupRequest.Common common(boolean privacy, boolean portraitRights) {
+    private SignupRequest.Common common(boolean privacy, boolean portraitRights, boolean trainingSafety) {
         return new SignupRequest.Common(
                 "홍길동", "1990-01-01", "010-1234-5678", "@guiderun",
-                "MALE", false, false, privacy, portraitRights);
+                "MALE", false, false, privacy, portraitRights, trainingSafety);
     }
 
-    private SignupRequest viRequest(boolean privacy, boolean portraitRights) {
+    private SignupRequest viRequest(boolean privacy, boolean portraitRights, boolean trainingSafety) {
         SignupRequest.Vi vi = new SignupRequest.Vi(
                 "A", "5km 30분", "초보 환영", true, "김가이드", "올림픽공원",
                 List.of("지인 소개"), "건강을 위해");
-        return new SignupRequest(UserType.VI, common(privacy, portraitRights), vi, null);
+        return new SignupRequest(UserType.VI, common(privacy, portraitRights, trainingSafety), vi, null);
     }
 
     private SignupRequest guideRequest() {
         SignupRequest.Guide guide = new SignupRequest.Guide(
                 "B", "10km 50분", "주말 선호", true, "박비아이", "5km 30분", "3", "6:00",
                 "한강공원", List.of("SNS"), "봉사하고 싶어서");
-        return new SignupRequest(UserType.GUIDE, common(true, true), null, guide);
+        return new SignupRequest(UserType.GUIDE, common(true, true, true), null, guide);
     }
 
     @Test
@@ -78,7 +78,7 @@ class SignupServiceTest {
         when(jwtProvider.createAccessToken(PRIVATE_ID)).thenReturn("access");
         when(jwtProvider.createRefreshToken(PRIVATE_ID)).thenReturn("refresh");
 
-        IntegratedSignupResponse response = signupService.signup(PRIVATE_ID, viRequest(true, true));
+        IntegratedSignupResponse response = signupService.signup(PRIVATE_ID, viRequest(true, true, true));
 
         assertThat(response.getUserId()).isEqualTo("vi_1");
         assertThat(response.getAccessToken()).isEqualTo("access");
@@ -112,7 +112,15 @@ class SignupServiceTest {
     @Test
     @DisplayName("약관에 동의하지 않으면 NotAgreeTermException(400)을 던진다")
     void notAgreeTerm() {
-        assertThatThrownBy(() -> signupService.signup(PRIVATE_ID, viRequest(false, true)))
+        assertThatThrownBy(() -> signupService.signup(PRIVATE_ID, viRequest(false, true, true)))
+                .isInstanceOf(NotAgreeTermException.class);
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("훈련 참여 및 안전 면책 약관에 동의하지 않으면 NotAgreeTermException(400)을 던진다")
+    void notAgreeTrainingSafetyTerm() {
+        assertThatThrownBy(() -> signupService.signup(PRIVATE_ID, viRequest(true, true, false)))
                 .isInstanceOf(NotAgreeTermException.class);
         verify(userRepository, never()).save(any());
     }
@@ -124,7 +132,7 @@ class SignupServiceTest {
         lenient().when(userService.extractNumber(anyString())).thenReturn("01012345678");
         lenient().when(userService.getUUID()).thenReturn("vi_1");
 
-        SignupRequest request = new SignupRequest(UserType.VI, common(true, true), null, null);
+        SignupRequest request = new SignupRequest(UserType.VI, common(true, true, true), null, null);
 
         assertThatThrownBy(() -> signupService.signup(PRIVATE_ID, request))
                 .isInstanceOf(BlankRequiredInfoException.class);
@@ -137,7 +145,7 @@ class SignupServiceTest {
                 .userId("u1").privateId(PRIVATE_ID).role(Role.ROLE_USER).type(UserType.VI).build();
         when(userRepository.findById(PRIVATE_ID)).thenReturn(Optional.of(existing));
 
-        assertThatThrownBy(() -> signupService.signup(PRIVATE_ID, viRequest(true, true)))
+        assertThatThrownBy(() -> signupService.signup(PRIVATE_ID, viRequest(true, true, true)))
                 .isInstanceOf(ExistUserException.class);
         verify(userRepository, never()).save(any());
     }


### PR DESCRIPTION
## 변경 배경

약관에 **훈련 참여 및 안전 면책 동의서**가 추가되어 신규 가입자와 기존 가입자의 동의 상태를 기존 약관 저장 구조에 반영합니다.

## 주요 변경 사항

- `ArchiveData`에 `trainingSafety` 동의 상태 추가
- 통합 회원가입 `POST /api/signup`의 `common.trainingSafety` 필수 검증 및 저장
- 기존 VI/Guide 회원가입 API에도 `trainingSafety` 검증 및 저장 추가
- 기존 회원의 약관 상태 조회 지원
  - `GET /api/user/permission`
- 기존 회원의 훈련 안전 면책 동의 API 추가
  - `PATCH /api/user/permission/training-safety`
  - 요청값은 `trainingSafety: true`만 허용
- 관리자 및 사용자 약관 조회 응답에 `trainingSafety` 추가
- 기존 `PATCH /api/user/permission`은 개인정보·초상권만 수정하도록 유지하여 구버전 요청이 신규 동의를 `false`로 덮어쓰지 않도록 처리

## DB 반영

운영 배포 전 아래 컬럼 추가가 필요합니다.

```sql
ALTER TABLE archive_data
    ADD COLUMN training_safety BIT(1) NOT NULL DEFAULT b'0';
```

기존 회원은 기본값 `false`로 설정되어 바텀시트 동의 대상이 됩니다.

## 검증

- `./gradlew compileJava compileTestJava` 성공
- `SignupServiceTest`, `SignupInfoServiceTest`, `SecurityConfigMypageAuthTest` 성공
- 전체 테스트 171개 중 168개 성공
- 나머지 3개는 로컬 `TEST_RDS` 환경변수 미설정으로 DB 컨텍스트 생성 단계에서 실패


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원가입 시 훈련 참여 및 안전 면책 동의 항목이 추가되었습니다.
  * 내 약관 동의 상태를 조회할 수 있습니다.
  * 훈련 안전 동의를 별도로 처리할 수 있습니다.
  * 회원 및 신청 정보에서 훈련 안전 동의 상태를 확인할 수 있습니다.

* **버그 수정**
  * 훈련 안전 동의 여부가 회원가입 및 신청 응답에 정확히 반영됩니다.
  * 필수 약관에 동의하지 않으면 회원가입이 제한됩니다.

* **테스트**
  * 동의 상태 조회, 동의 처리 및 미동의 요청에 대한 검증이 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->