### PR TITLE
feat: 매칭 현황 myPartners에 기본 그룹 정보 추가

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/dto/response/match/MatchingStatusUser.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/match/MatchingStatusUser.java
@@ -12,5 +12,6 @@ public class MatchingStatusUser {
     private String userId;
     private String name;
     private UserType type;
-    private String applyGroup;
+    private String applyGroup; //이벤트 참가 신청 시 입력한 희망 그룹
+    private String defaultGroup; //회원가입 시 입력한 기본 그룹
 }

--- a/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
@@ -289,6 +289,7 @@ public class EventMatchingService {
                         .name(guide.getName())
                         .type(guide.getType())
                         .applyGroup(form != null ? form.getHopeTeam() : null)
+                        .defaultGroup(guide.getRecordDegree())
                         .build());
             }
         } else if (loginUser.getType() == UserType.GUIDE) {
@@ -306,6 +307,7 @@ public class EventMatchingService {
                             .name(vi.getName())
                             .type(vi.getType())
                             .applyGroup(form != null ? form.getHopeTeam() : null)
+                            .defaultGroup(vi.getRecordDegree())
                             .build());
                 }
             }


### PR DESCRIPTION
## 개요
`GET /event/{eventId}/matching/status` 응답의 `myPartners`에 회원가입 시 입력한 **기본 그룹**(`defaultGroup`) 정보를 추가합니다.

## 변경 사항
- `MatchingStatusUser`에 `defaultGroup` 필드 추가
  - `applyGroup`: 이벤트 참가 신청 시 입력한 희망 그룹 (`EventForm.hopeTeam`)
  - `defaultGroup`: 회원가입 시 입력한 기본 그룹 (`User.recordDegree`)
- `EventMatchingService.buildMyPartners()`에서 VI/GUIDE 양쪽 분기 모두 파트너의 `User.recordDegree`를 `defaultGroup`으로 매핑

## 응답 예시 (myPartners)
```jsonc
"myPartners": [
  {
    "userId": "string",
    "name": "string",
    "type": "VI | GUIDE",
    "applyGroup": "string",   // 이벤트 신청 시 희망 그룹
    "defaultGroup": "string"  // 회원가입 시 기본 그룹
  }
]
```

## 참고
- `defaultGroup`은 `MatchingStatusUser`에 추가되어 `groups[].rows[]`의 `vi`/`guides`에도 필드로 존재하나 해당 위치에서는 채우지 않아 `null`로 반환됩니다. 이번 요청 범위(`myPartners`)에만 값을 채웠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 매칭 상태에서 회원가입 시 설정한 기본 그룹 정보를 확인할 수 있습니다.
  - 이벤트 신청 시 입력한 희망 그룹과 기본 그룹이 구분되어 표시됩니다.
  - 파트너 정보 조회 시 기본 그룹 정보가 정확하게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->