### PR TITLE
feat: 매칭 생성 API를 replace(교체) 시맨틱으로 변경

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/dto/request/match/MatchingCreateRequest.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/request/match/MatchingCreateRequest.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.entity.dto.request.match;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,6 +8,7 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class MatchingCreateRequest {
     private String viId;
     private List<String> guideIds;

--- a/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
@@ -8,6 +8,7 @@ import com.guide.run.event.entity.dto.response.match.*;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.EventFormStatus;
+import com.guide.run.global.exception.event.logic.EventValidationException;
 import com.guide.run.global.exception.event.resource.NotExistEventException;
 import com.guide.run.global.exception.event.resource.NotExistFormException;
 import com.guide.run.global.exception.user.resource.NotExistUserException;
@@ -51,7 +52,30 @@ public class EventMatchingService {
     public MatchingCreateResponse createMatching(Long eventId, MatchingCreateRequest request) {
         eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
 
-        for (String guideId : request.getGuideIds()) {
+        List<String> guideIds = request.getGuideIds();
+        // 빈 배열 정책: 최소 1명 이상 선택해야 함 (FE 합의 전 기본값 — 전량 해제는 DELETE 엔드포인트 사용)
+        if (guideIds == null || guideIds.isEmpty()) {
+            throw new EventValidationException("매칭할 가이드를 최소 1명 이상 선택해야 합니다.");
+        }
+
+        // === replace 시맨틱: 요청 guideIds 를 이 VI 의 '최종 가이드 집합'으로 맞춘다 ===
+        // 요청에서 빠진 기존 매칭 가이드는 먼저 해제(매칭 삭제 + 대기 전환 + 파트너 원복)한다.
+        // 요청에 남아있는/새로 추가되는 가이드는 아래 matchUser 루프가 처리하며,
+        // 다른 VI 에 물린 가이드 자동 재배정(steal) 로직도 그대로 동작한다.
+        User vi = userRepository.findUserByUserId(request.getViId()).orElseThrow(NotExistUserException::new);
+        Set<String> requestGuidePrivateIds = new HashSet<>();
+        for (String guideId : guideIds) {
+            userRepository.findUserByUserId(guideId)
+                    .ifPresent(g -> requestGuidePrivateIds.add(g.getPrivateId()));
+        }
+        List<Matching> currentMatchings = matchingRepository.findAllByEventIdAndViId(eventId, vi.getPrivateId());
+        for (Matching current : currentMatchings) {
+            if (!requestGuidePrivateIds.contains(current.getGuideId())) {
+                releaseGuideFromMatching(eventId, current);
+            }
+        }
+
+        for (String guideId : guideIds) {
             matchUser(eventId, request.getViId(), guideId);
         }
 
@@ -423,6 +447,26 @@ public class EventMatchingService {
                         .build())
                 .groups(groups)
                 .build();
+    }
+
+    /**
+     * replace 시맨틱에서 요청 guideIds 에 포함되지 않은 기존 매칭 가이드를 해제한다.
+     * 매칭 row 삭제 → 가이드를 대기(UnMatching)로 전환 → 가이드 파트너/출석 상태 원복.
+     * (다른 VI 로 옮겨가는 steal 과 달리, 여기서는 가이드가 대기로 돌아가므로 UnMatching 저장이 필요하다.)
+     */
+    private void releaseGuideFromMatching(Long eventId, Matching matching) {
+        User guide = userRepository.findUserByPrivateId(matching.getGuideId()).orElseThrow(NotExistUserException::new);
+
+        // 가이드 파트너/출석 상태 원복
+        partnerService.setNotAttendGuidePartner(eventId, guide);
+
+        matchingRepository.delete(matching);
+
+        // 해제된 가이드는 대기로 전환
+        unMatchingRepository.save(UnMatching.builder()
+                .eventId(eventId)
+                .privateId(matching.getGuideId())
+                .build());
     }
 
     private void updatePartnerOnAttendance(Long eventId, User guide) {

--- a/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventMatchingServiceTest.java
@@ -8,11 +8,14 @@ import com.guide.run.event.entity.dto.response.match.MatchingCompletedFlatDto;
 import com.guide.run.event.entity.dto.response.match.MatchingCompletedResponse;
 import com.guide.run.event.entity.dto.response.match.MatchingStatusGroup;
 import com.guide.run.event.entity.dto.response.match.MatchingWaitingResponse;
+import com.guide.run.event.entity.dto.request.match.MatchingCreateRequest;
 import com.guide.run.event.entity.dto.response.match.MatchingWaitingFlatDto;
 import com.guide.run.event.entity.repository.EventFormRepository;
+import com.guide.run.global.exception.event.logic.EventValidationException;
 import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.partner.entity.matching.Matching;
+import com.guide.run.partner.entity.matching.UnMatching;
 import com.guide.run.partner.entity.matching.repository.MatchingRepository;
 import com.guide.run.partner.entity.matching.repository.UnMatchingRepository;
 import com.guide.run.partner.service.PartnerService;
@@ -31,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -262,6 +266,63 @@ class EventMatchingServiceTest {
         assertThat(response.getGroups().get(0).getParticipants())
                 .extracting("type")
                 .containsExactly(UserType.VI, UserType.VI, UserType.GUIDE, UserType.GUIDE);
+    }
+
+    @Test
+    @DisplayName("매칭 생성은 replace 시맨틱: 요청 guideIds 에 없는 기존 가이드를 해제하고 대기로 전환한다")
+    void createMatchingReplacesGuideSet() {
+        User vi = User.builder()
+                .privateId("vi-private").userId("vi-user").type(UserType.VI).build();
+        User g1 = User.builder()
+                .privateId("g1-private").userId("g1-user").type(UserType.GUIDE).build();
+        User g2 = User.builder()
+                .privateId("g2-private").userId("g2-user").type(UserType.GUIDE).build();
+        Matching g1Matching = Matching.builder()
+                .eventId(1L).guideId("g1-private").viId("vi-private").build();
+        EventForm viForm = EventForm.builder()
+                .eventId(1L).privateId("vi-private").hopeTeam("A").status(EventFormStatus.APPLIED).build();
+        EventForm g2Form = EventForm.builder()
+                .eventId(1L).privateId("g2-private").hopeTeam("A").status(EventFormStatus.APPLIED).build();
+
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(Event.builder().id(1L).build()));
+        when(userRepository.findUserByUserId("vi-user")).thenReturn(Optional.of(vi));
+        when(userRepository.findUserByUserId("g2-user")).thenReturn(Optional.of(g2));
+        when(userRepository.findUserByPrivateId("g1-private")).thenReturn(Optional.of(g1));
+        // 현재 VI-A ↔ [G1]
+        when(matchingRepository.findAllByEventIdAndViId(1L, "vi-private")).thenReturn(List.of(g1Matching));
+        when(eventFormRepository.findByEventIdAndPrivateIdAndStatus(1L, "vi-private", EventFormStatus.APPLIED))
+                .thenReturn(viForm);
+        when(eventFormRepository.findByEventIdAndPrivateIdAndStatus(1L, "g2-private", EventFormStatus.APPLIED))
+                .thenReturn(g2Form);
+        when(matchingRepository.findByEventIdAndGuideId(1L, "g2-private")).thenReturn(null);
+        when(unMatchingRepository.findByPrivateIdAndEventId("vi-private", 1L)).thenReturn(Optional.empty());
+        lenient().when(attendanceRepository.findByEventIdAndPrivateId(1L, "g2-private")).thenReturn(null);
+
+        MatchingCreateRequest request = new MatchingCreateRequest("vi-user", List.of("g2-user"));
+        eventMatchingService.createMatching(1L, request);
+
+        // G1 은 매칭 해제 + 파트너 원복 + 대기 전환
+        verify(matchingRepository).delete(g1Matching);
+        verify(partnerService).setNotAttendGuidePartner(1L, g1);
+        ArgumentCaptor<UnMatching> unMatchingCaptor = ArgumentCaptor.forClass(UnMatching.class);
+        verify(unMatchingRepository).save(unMatchingCaptor.capture());
+        assertThat(unMatchingCaptor.getValue().getPrivateId()).isEqualTo("g1-private");
+        // G2 는 VI-A 에 매칭 저장
+        ArgumentCaptor<Matching> matchingCaptor = ArgumentCaptor.forClass(Matching.class);
+        verify(matchingRepository).save(matchingCaptor.capture());
+        assertThat(matchingCaptor.getValue().getGuideId()).isEqualTo("g2-private");
+        assertThat(matchingCaptor.getValue().getViId()).isEqualTo("vi-private");
+    }
+
+    @Test
+    @DisplayName("매칭 생성은 빈 guideIds 를 거절한다(최소 1명)")
+    void createMatchingRejectsEmptyGuideIds() {
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(Event.builder().id(1L).build()));
+
+        MatchingCreateRequest request = new MatchingCreateRequest("vi-user", List.of());
+
+        assertThatThrownBy(() -> eventMatchingService.createMatching(1L, request))
+                .isInstanceOf(EventValidationException.class);
     }
 
     private List<MatchingWaitingFlatDto> unsortedWaitingParticipants() {


### PR DESCRIPTION
## 배경
프론트 매칭하기 페이지 개편으로, 재매칭이 "취소 없이 완료 상태에서 다시 선택 → 그 구성 그대로 재매칭"으로 바뀐다. 하단 CTA가 "이대로 매칭하기"라서 요청의 `guideIds`가 해당 VI의 **최종 가이드 집합**이어야 한다.

기존 `POST /api/event/{eventId}/matching`은 `guideIds`를 한 건씩 add/upsert 처리해, 요청에서 **빠진** 기존 가이드가 그대로 남는 문제가 있었다(replace가 아니라 add).

## 변경 내용
- **replace 시맨틱**: `createMatching`에서 `matchUser` 루프 직전에, 대상 VI의 현재 매칭 가이드 중 요청 `guideIds`에 **없는** 가이드를 먼저 해제한다. 최종 상태는 `해당 VI의 매칭 가이드 == 요청 guideIds`(완전 일치, 멱등).
- **가이드 해제**(`releaseGuideFromMatching`): 매칭 row 삭제 → 대기(UnMatching) 전환 → 파트너/출석 상태 원복.
- **재배정 유지**: 다른 VI에 물린 가이드 자동 재배정(steal) 로직은 그대로 유지.
- **빈 배열 정책**: 빈 `guideIds`는 `EventValidationException`(HTTP 400)으로 거절(최소 1명). 전량 해제는 기존 DELETE 엔드포인트 사용.
- `MatchingCreateRequest`에 `@AllArgsConstructor` 추가(테스트용, Jackson 역직렬화 영향 없음).

## 검증
- `./gradlew compileJava` 통과, `EventMatchingServiceTest` 8건 전부 통과(신규 2건 포함).
- ✅ VI-A↔[G1] + `{A,[G2]}` → VI-A↔[G2] (G1 자동 해제·대기 전환) — 신규 테스트
- ✅ 빈 `guideIds` → 400 거절 — 신규 테스트
- VI-A↔[G1] + `{A,[G1,G2]}` → VI-A↔[G1,G2] (기존 matchUser 재사용)
- G2가 VI-B 소속이면 VI-B에서 자동 제거 (기존 steal 로직 유지)
- PK `(eventId, guideId)` 충돌 없음: 제거 대상은 요청 집합과 서로소라 delete→save 순서 안전

## ⚠️ 문서 확인 필요
Notion "확정 API 명세 > 매칭"의 검증 정책("이미 매칭된 Guide/VI 거절")은 실제 동작(재배정 + replace)과 불일치하는 **구버전**이다. 담당자 확인 후 갱신 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 매칭 생성 시 요청된 가이드 목록에 맞춰 기존 매칭을 자동으로 조정합니다.
  - 요청 목록에서 제외된 가이드는 매칭이 해제되고 대기 상태로 전환됩니다.

- **버그 수정**
  - 가이드 목록이 비어 있거나 제공되지 않은 매칭 요청을 유효성 오류로 처리합니다.

- **테스트**
  - 가이드 매칭 목록 교체 및 빈 목록 요청에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->