### PR TITLE
Fix: 미사용 Event.distance 필드 제거 및 배포 실패 원인 로그 보강

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/Event.java
+++ b/run/src/main/java/com/guide/run/event/entity/Event.java
@@ -56,7 +56,6 @@ public class Event extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private CityName cityName; //이벤트 지역
 
-    private Double distance; //러닝 거리 (km)
     private boolean isPrivate;
     private BigDecimal expectedRunningDistanceKm;
 

--- a/run/src/main/resources/logback-spring.xml
+++ b/run/src/main/resources/logback-spring.xml
@@ -113,8 +113,8 @@
         </logger>
     </springProfile>
 
-    <!-- ===== 운영 서버 프로파일 ===== -->
-    <springProfile name="prod">
+    <!-- ===== 운영 서버 프로파일 (prod / batch) ===== -->
+    <springProfile name="prod | batch">
         <root level="WARN">
             <appender-ref ref="FILE_ALL"/>
             <appender-ref ref="FILE_ERROR"/>

--- a/scripts/validate_service.sh
+++ b/scripts/validate_service.sh
@@ -1,18 +1,60 @@
 #!/bin/bash
 
+DEPLOY_DIR=/home/ubuntu/deploy
+LOG_DIR=$DEPLOY_DIR/logs
+JAR_PATTERN='java.*run-0\.0\.1-SNAPSHOT\.jar'
+MAX_WAIT=90
+
 echo ">>> Validating service..."
 
-# 최대 90초 대기하면서 health check
-for i in $(seq 1 90); do
-  # 포트가 열려있는지만 확인 (401도 서버가 정상 기동된 것)
+dump_diagnostics() {
+  echo ""
+  echo ">>> ================= 진단 정보 ================="
+
+  local pids
+  pids=$(pgrep -f "$JAR_PATTERN" | tr '\n' ' ')
+  if [ -n "$pids" ]; then
+    echo ">>> JVM 프로세스: 살아있음 (PID $pids)"
+  else
+    echo ">>> JVM 프로세스: 종료됨"
+  fi
+
+  echo ""
+  echo ">>> --- 로그 파일 목록 (갱신 시각으로 이전 배포 로그와 구분) ---"
+  ls -l "$DEPLOY_DIR/nohup.out" "$LOG_DIR" 2>&1
+
+  echo ""
+  echo ">>> --- tail -80 $LOG_DIR/guiderun-error.log ---"
+  tail -80 "$LOG_DIR/guiderun-error.log" 2>&1
+
+  echo ""
+  echo ">>> --- tail -40 $DEPLOY_DIR/nohup.out ---"
+  tail -40 "$DEPLOY_DIR/nohup.out" 2>&1
+
+  echo ""
+  echo ">>> --- tail -40 $LOG_DIR/guiderun-app.log ---"
+  tail -40 "$LOG_DIR/guiderun-app.log" 2>&1
+
+  echo ">>> =============================================="
+}
+
+for i in $(seq 1 $MAX_WAIT); do
   STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080 2>/dev/null)
   if [ -n "$STATUS" ] && [ "$STATUS" != "000" ]; then
     echo ">>> Application is running! (HTTP $STATUS)"
     exit 0
   fi
-  echo ">>> Waiting for application to start... ($i/90)"
+
+  if [ "$i" -ge 3 ] && ! pgrep -f "$JAR_PATTERN" > /dev/null 2>&1; then
+    echo ">>> ERROR: JVM process exited after ${i}s (application failed to boot)"
+    dump_diagnostics
+    exit 1
+  fi
+
+  echo ">>> Waiting for application to start... ($i/$MAX_WAIT)"
   sleep 1
 done
 
-echo ">>> ERROR: Application failed to start within 90 seconds"
+echo ">>> ERROR: Application failed to start within ${MAX_WAIT} seconds"
+dump_diagnostics
 exit 1


### PR DESCRIPTION
## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
- prod 배포가 `Schema-validation: missing column [distance] in table [event]` 로 실패한 원인 제거
- `validate_service.sh` 가 실패 시 원인을 남기지 않던 문제 수정
- batch 프로파일에서 로그가 어디에도 남지 않던 문제 수정

## **변경 내용**

### 1. 미사용 `Event.distance` 필드 제거

prod/batch 는 `ddl-auto: validate` 이므로 엔티티에 선언된 컬럼이 운영 DB에 없으면 `EntityManagerFactory` 생성 단계에서 기동이 실패합니다. dev 는 `ddl-auto: update` 라 Hibernate 가 자동 생성해서 이 문제가 드러나지 않았습니다.

`Event.distance` 는 코드 전체에 사용처가 없는 잔재 필드입니다.
- `getDistance()` 호출, 빌더 `.distance(...)` 사용 0건
- `new Event(...)` 위치 인자 호출 0건 (전부 빌더 32곳) → `@AllArgsConstructor` 시그니처 변경 영향 없음
- 실제 러닝 거리는 `expectedRunningDistanceKm` 이며, `EventRepositoryImplTest` 가 이미 `sum(event.distance)` 를 사용하지 않아야 한다고 검증 중

운영 DB에 쓰지 않는 컬럼을 추가하는 대신 필드를 제거했습니다. **이 PR은 DB 변경을 필요로 하지 않습니다** (`event_additional_*` 3개 테이블과 `event_form`, `archive_data` 신규 컬럼은 이미 반영되어 있음).

### 2. `validate_service.sh` 실패 원인 출력 + fail-fast

기존에는 실패 시 `exit 1` 만 반환해 CodeDeploy 로그에 원인이 전혀 남지 않았습니다. prod/batch 프로파일에는 CONSOLE appender 가 없어 `nohup.out` 에는 배너만 남고 스택트레이스는 파일 로그에만 기록되기 때문입니다.

- 실패 시 JVM 프로세스 상태, 로그 파일 갱신 시각, `guiderun-error.log`(80줄), `nohup.out`(40줄), `guiderun-app.log`(40줄) 출력
- 에러 로그를 먼저 출력하고 `nohup.out` 도 함께 출력 (jar 누락·OOM 등 JVM 레벨 실패는 `nohup.out` 에만 남음)
- JVM 이 이미 종료된 경우 90초를 기다리지 않고 즉시 실패

### 3. batch 프로파일 로그 유실 수정

`logback-spring.xml` 에 batch 프로파일 블록이 없어서 batch 인스턴스(main-2)는 root 로거에 appender 가 하나도 붙지 않았습니다. 기동에 실패해도 파일 로그도 `nohup.out` 도 남지 않아, 2번의 진단 정보 출력조차 읽을 로그가 없는 상태였습니다.

`<springProfile name="prod | batch">` 로 prod 와 동일한 appender 구성을 공유합니다. 블록을 복제하지 않은 이유는 설정이 갈라지면 한쪽만 수정하는 사고가 재발하기 때문이고, prod 와 batch 는 서로 다른 EC2 인스턴스라 로그 파일명이 겹치지 않습니다.

## **검증**

| 항목 | 결과 |
|---|---|
| `./gradlew compileJava` / `compileTestJava` / `bootJar` | 모두 성공 |
| `EventRepositoryImplTest` | tests=6, failures=0, errors=0 |
| `validate_service.sh` 실패 경로 (경로 치환 후 실제 실행) | exit 1, 2초에 종료, 에러 로그 정상 노출 |
| `validate_service.sh` 성공 경로 (포트 리스너 기동) | exit 0, `HTTP 200` |
| batch 프로파일 로그 (동일 jar, DB/Redis 를 죽은 주소로 지정해 기동 실패 유도) | **수정 전**: `logs/` 디렉터리 미생성, `nohup.out` 스택트레이스 0건 / **수정 후**: `guiderun-error.log` 에 `HikariPool` 초기화 실패 트레이스 기록 |

## **후속 작업 (이 PR 범위 아님)**

- Flyway 도입: dev(`update`) / prod(`validate`) 비대칭 때문에 스키마 누락이 dev 에서 드러나지 않는 구조적 원인. 현재 prod 실제 스키마와 Hibernate 기대 정의에 이미 드리프트 존재 (`expected_running_distance_km` `decimal(10,2)` vs `decimal(38,2)`, `phone_number` `varchar(20)` vs `varchar(255)`, `canceled_at` `datetime` vs `datetime(6)`)
- `local`/`dev`/`prod`/`batch` 외 프로파일로 기동하면 여전히 `<root>` 가 정의되지 않아 로그가 남지 않음

## **관련 이슈**
Resolves: 없음

See also: 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 서비스 검증 과정에서 배포 상태와 로그를 더욱 정확하게 확인합니다.
  * 서비스 시작 실패나 시간 초과 시 JVM 상태와 주요 로그를 제공해 문제 진단이 쉬워졌습니다.
  * 운영 및 배치 환경에 동일한 로그 설정이 적용됩니다.
* **변경 사항**
  * 이벤트에서 러닝 거리 정보가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->