### PR TITLE
Fix: 이벤트 생성/수정 시 도시 미전달을 SEOUL 기본값으로 처리

### DIFF
--- a/run/src/main/java/com/guide/run/event/service/EventService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventService.java
@@ -13,6 +13,7 @@ import com.guide.run.event.entity.dto.response.EventRunningDistancePatchResponse
 import com.guide.run.event.entity.dto.response.EventUpdatedResponse;
 import com.guide.run.event.entity.dto.response.MissingRunningDistanceGetResponse;
 import com.guide.run.event.entity.repository.*;
+import com.guide.run.event.entity.type.CityName;
 import com.guide.run.event.entity.type.EventCategory;
 import com.guide.run.event.entity.type.EventFormStatus;
 import com.guide.run.event.entity.type.EventRecruitStatus;
@@ -67,6 +68,9 @@ public class EventService {
 
     private final EventAdditionalInfoService eventAdditionalInfoService;
 
+    private CityName resolveCityName(CityName cityName) {
+        return cityName == null ? CityName.SEOUL : cityName;
+    }
 
     @Transactional
     public EventCreatedResponse eventCreate(EventCreateRequest request, String privateId) {
@@ -120,7 +124,7 @@ public class EventService {
                 .maxNumG(request.getMinNumG())
                 .place(request.getPlace())
                 .status(status)
-                .cityName(request.getCityName())
+                .cityName(resolveCityName(request.getCityName()))
                 .eventCategory(eventCategory)
                 .content(request.getContent())
                 .isPrivate(Boolean.TRUE.equals(request.getIsPrivate()))
@@ -212,7 +216,7 @@ public class EventService {
                     .place(request.getPlace())
                     .status(event.getStatus())
                     .content(request.getContent())
-                    .cityName(request.getCityName())
+                    .cityName(resolveCityName(request.getCityName()))
                     .eventCategory(eventCategory)
                     .isPrivate(Boolean.TRUE.equals(request.getIsPrivate()))
                     .expectedRunningDistanceKm(request.getExpectedRunningDistanceKm())

--- a/run/src/test/java/com/guide/run/event/service/EventRenewalServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventRenewalServiceTest.java
@@ -192,6 +192,50 @@ class EventRenewalServiceTest {
     }
 
     @Test
+    @DisplayName("이벤트 생성 시 도시를 보내지 않으면 SEOUL 로 저장한다")
+    void eventCreateDefaultsCityNameToSeoulWhenMissing() {
+        User organizer = createUser("organizer-private", "organizer-user", "홍길동", UserType.GUIDE);
+        EventCreateRequest request = createEventRequest(false, null, null, null);
+
+        when(userRepository.findUserByPrivateId("organizer-private")).thenReturn(Optional.of(organizer));
+        when(timeFormatter.getDateTime("2026-06-20", "09:00"))
+                .thenReturn(LocalDateTime.of(2026, 6, 20, 9, 0));
+        when(timeFormatter.getDateTime("2026-06-20", "11:00"))
+                .thenReturn(LocalDateTime.of(2026, 6, 20, 11, 0));
+        when(eventRepository.save(any(Event.class)))
+                .thenReturn(Event.builder().id(99L).isApprove(true).build());
+
+        eventService.eventCreate(request, "organizer-private");
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventRepository).save(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getCityName()).isEqualTo(CityName.SEOUL);
+    }
+
+    @Test
+    @DisplayName("이벤트 수정 시 도시를 보내지 않으면 SEOUL 로 저장한다")
+    void eventUpdateDefaultsCityNameToSeoulWhenMissing() {
+        User organizer = createUser("organizer-private", "organizer-user", "홍길동", UserType.GUIDE);
+        Event event = createEvent("organizer-private");
+        EventCreateRequest request = createEventRequest(false, null, null, null);
+
+        when(userRepository.findUserByPrivateId("organizer-private")).thenReturn(Optional.of(organizer));
+        when(timeFormatter.getDateTime("2026-06-20", "09:00"))
+                .thenReturn(LocalDateTime.of(2026, 6, 20, 9, 0));
+        when(timeFormatter.getDateTime("2026-06-20", "11:00"))
+                .thenReturn(LocalDateTime.of(2026, 6, 20, 11, 0));
+        when(eventRepository.findById(99L)).thenReturn(Optional.of(event));
+        when(eventRepository.save(any(Event.class)))
+                .thenReturn(Event.builder().id(99L).isApprove(true).build());
+
+        eventService.eventUpdate(request, "organizer-private", 99L);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventRepository).save(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getCityName()).isEqualTo(CityName.SEOUL);
+    }
+
+    @Test
     @DisplayName("이벤트 수정은 신청자가 있으면 추가 질문 변경을 거부한다")
     void eventUpdateRejectsAdditionalQuestionsWhenAppliedFormExists() {
         User organizer = createUser("organizer-private", "organizer-user", "홍길동", UserType.GUIDE);
@@ -544,6 +588,15 @@ class EventRenewalServiceTest {
             BigDecimal expectedRunningDistanceKm,
             List<EventCreateRequest.AdditionalQuestionRequest> additionalQuestions
     ) {
+        return createEventRequest(isPrivate, expectedRunningDistanceKm, additionalQuestions, CityName.SEOUL);
+    }
+
+    private EventCreateRequest createEventRequest(
+            Boolean isPrivate,
+            BigDecimal expectedRunningDistanceKm,
+            List<EventCreateRequest.AdditionalQuestionRequest> additionalQuestions,
+            CityName cityName
+    ) {
         return new EventCreateRequest(
                 LocalDate.of(2026, 6, 1),
                 LocalDate.of(2026, 6, 10),
@@ -557,7 +610,7 @@ class EventRenewalServiceTest {
                 "서울",
                 "내용",
                 EventCategory.GENERAL,
-                CityName.SEOUL,
+                cityName,
                 isPrivate,
                 expectedRunningDistanceKm,
                 additionalQuestions


### PR DESCRIPTION
## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
- 이벤트 생성 시 `cityName` 을 보내지 않으면 `SEOUL` 기본값으로 저장
- 이벤트 수정도 동일하게 처리 (누락 시 기존 도시가 null 로 덮이는 문제 해결)
- 생성/수정 각각에 대한 테스트 추가

## **변경 내용**

### 문제

`POST /api/event` 요청에 `cityName` 이 없으면 500 이 발생했습니다.

```
DataIntegrityViolationException: could not execute statement
[Column 'city_name' cannot be null]
insert into event (city_name, content, ...) values (?,?,...)
```

운영 DB 의 `event.city_name` 은 `enum('SEOUL','BUSAN') NOT NULL DEFAULT 'SEOUL'` 이지만, Hibernate 가 `city_name` 을 INSERT 컬럼 목록에 **명시적으로 포함**해서 null 을 넣기 때문에 컬럼 DEFAULT 가 적용되지 않습니다. 엔티티 필드는 nullable 로 선언되어 있어 `ddl-auto: validate` 도 이 불일치를 잡지 못합니다.

`cityName` 은 더 이상 클라이언트가 보내지 않는 값인데 요청 값을 그대로 엔티티에 넣고 있었습니다.

### 수정

`eventCategory` 가 null 일 때 `GENERAL` 로 채우는 기존 처리와 같은 방식으로 `cityName` 도 기본값을 채웁니다.

```java
private CityName resolveCityName(CityName cityName) {
    return cityName == null ? CityName.SEOUL : cityName;
}
```

생성(`eventCreate`)과 수정(`eventUpdate`) 두 경로에 모두 적용했습니다. **수정 경로도 함께 고친 이유**는 `eventUpdate` 가 요청 값으로 엔티티를 전부 재조립하기 때문입니다. `cityName` 을 보내지 않으면 기존에 저장된 도시가 null 로 덮여 같은 오류가 발생하므로, 생성만 고치면 수정에서 그대로 터집니다.

DB 스키마 변경은 필요하지 않습니다.

## **검증**

TDD 로 진행했습니다. 먼저 테스트를 추가해 프로덕션 오류가 재현되는 것을 확인했습니다.

```
EventRenewalServiceTest > 이벤트 생성 시 도시를 보내지 않으면 SEOUL 로 저장한다 FAILED
  expected: SEOUL but was: null
EventRenewalServiceTest > 이벤트 수정 시 도시를 보내지 않으면 SEOUL 로 저장한다 FAILED
  expected: SEOUL but was: null
```

구현 후:

| 항목 | 결과 |
|---|---|
| `EventRenewalServiceTest` | tests=17, failures=0, errors=0 |
| `com.guide.run.event.*` 전체 | tests=86, failures=0, errors=0 |
| `./gradlew compileJava` | 성공 |

기존 `createEventRequest` 헬퍼에 `cityName` 파라미터를 받는 오버로드를 추가하고, 기존 3-arg 시그니처는 `SEOUL` 로 위임하게 해서 나머지 테스트는 변경하지 않았습니다.

## **후속 작업 (이 PR 범위 아님)**

`EventCreateRequest` 에는 `@NotNull` 이 하나도 없어서 `name`, `date`, `startTime`, `recruitStartDate` 가 누락되면 각각 NPE 나 DB 제약 위반으로 500 이 발생합니다 (400 이어야 함). 프론트가 실제로 보내는 필드를 확인한 뒤 정리가 필요합니다.

## **관련 이슈**
Resolves: 없음

See also: #479
