### PR TITLE
Fix: 러닝거리 미입력 조회를 최신 종료 이벤트 기준으로 수정

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepository.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepository.java
@@ -12,7 +12,7 @@ public interface EventRepository extends JpaRepository<Event,Long>, EventReposit
     Page<Event> findAll( Pageable pageable);
     List<Event> findAllByOrganizer(String organizer);
 
-    List<Event> findAllByOrganizerAndEndTimeBeforeAndExpectedRunningDistanceKmIsNullOrderByEndTimeDescIdDesc(
+    List<Event> findAllByOrganizerAndEndTimeBeforeOrderByEndTimeDescIdDesc(
             String organizer,
             LocalDateTime now,
             Pageable pageable

--- a/run/src/main/java/com/guide/run/event/service/EventService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventService.java
@@ -292,12 +292,13 @@ public class EventService {
 
     public MissingRunningDistanceGetResponse getMissingRunningDistance(String privateId) {
         List<MissingRunningDistanceGetResponse.Item> items = eventRepository
-                .findAllByOrganizerAndEndTimeBeforeAndExpectedRunningDistanceKmIsNullOrderByEndTimeDescIdDesc(
+                .findAllByOrganizerAndEndTimeBeforeOrderByEndTimeDescIdDesc(
                         privateId,
                         EventTemporalStatusResolver.now(),
                         PageRequest.of(0, 1)
                 )
                 .stream()
+                .filter(event -> event.getExpectedRunningDistanceKm() == null)
                 .map(event -> MissingRunningDistanceGetResponse.Item.builder()
                         .eventId(event.getId())
                         .name(event.getName())

--- a/run/src/test/java/com/guide/run/event/service/EventRenewalServiceTest.java
+++ b/run/src/test/java/com/guide/run/event/service/EventRenewalServiceTest.java
@@ -278,7 +278,7 @@ class EventRenewalServiceTest {
     @DisplayName("러닝 거리 미입력 이벤트 조회는 내가 주최한 종료 이벤트 중 최신 1개를 반환한다")
     void getMissingRunningDistanceReturnsLatestOrganizerEndedEvent() {
         Event missingDistanceEvent = createEndedEventWithoutExpectedDistance(10L, "상계천천히달리기");
-        when(eventRepository.findAllByOrganizerAndEndTimeBeforeAndExpectedRunningDistanceKmIsNullOrderByEndTimeDescIdDesc(
+        when(eventRepository.findAllByOrganizerAndEndTimeBeforeOrderByEndTimeDescIdDesc(
                 eq("organizer-private"),
                 any(LocalDateTime.class),
                 any(Pageable.class)
@@ -291,6 +291,42 @@ class EventRenewalServiceTest {
         assertThat(item.getEventId()).isEqualTo(10L);
         assertThat(item.getName()).isEqualTo("상계천천히달리기");
         assertThat(item.getDateText()).isEqualTo("6월 1일 (월)");
+    }
+
+    @Test
+    @DisplayName("가장 최신 종료 이벤트에 러닝 거리가 이미 있으면 빈 목록을 반환한다")
+    void getMissingRunningDistanceReturnsEmptyWhenLatestEndedEventAlreadyHasDistance() {
+        Event latestEventWithDistance = createEndedEventWithExpectedDistance(20L, "최신이벤트", new BigDecimal("15.00"));
+        when(eventRepository.findAllByOrganizerAndEndTimeBeforeOrderByEndTimeDescIdDesc(
+                eq("organizer-private"),
+                any(LocalDateTime.class),
+                any(Pageable.class)
+        )).thenReturn(List.of(latestEventWithDistance));
+
+        MissingRunningDistanceGetResponse response = eventService.getMissingRunningDistance("organizer-private");
+
+        assertThat(response.getItems()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("러닝 거리 미입력 이벤트 조회는 최신 종료 이벤트 1건만 조회한다")
+    void getMissingRunningDistanceQueriesOnlyTheSingleLatestEndedEvent() {
+        when(eventRepository.findAllByOrganizerAndEndTimeBeforeOrderByEndTimeDescIdDesc(
+                eq("organizer-private"),
+                any(LocalDateTime.class),
+                any(Pageable.class)
+        )).thenReturn(List.of());
+
+        eventService.getMissingRunningDistance("organizer-private");
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(eventRepository).findAllByOrganizerAndEndTimeBeforeOrderByEndTimeDescIdDesc(
+                eq("organizer-private"),
+                any(LocalDateTime.class),
+                pageableCaptor.capture()
+        );
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(1);
+        assertThat(pageableCaptor.getValue().getPageNumber()).isZero();
     }
 
     @Test
@@ -580,6 +616,17 @@ class EventRenewalServiceTest {
                 .startTime(LocalDateTime.of(2026, 6, 1, 9, 0))
                 .endTime(LocalDateTime.of(2026, 6, 1, 11, 0))
                 .expectedRunningDistanceKm(null)
+                .build();
+    }
+
+    private Event createEndedEventWithExpectedDistance(Long eventId, String name, BigDecimal distance) {
+        return Event.builder()
+                .id(eventId)
+                .organizer("organizer-private")
+                .name(name)
+                .startTime(LocalDateTime.of(2026, 7, 1, 9, 0))
+                .endTime(LocalDateTime.of(2026, 7, 1, 11, 0))
+                .expectedRunningDistanceKm(distance)
                 .build();
     }
 


### PR DESCRIPTION
## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
- `GET /api/event/missing-running-distance` 가 **가장 최신 종료 이벤트의 거리가 null 일 때만** 응답하도록 수정
- DB 레벨 `IS NULL` 필터를 제거하고 서비스에서 null 여부를 판정
- 최신 이벤트에 거리가 이미 있는 경우 / 조회 건수 1건 보장 테스트 추가

## **변경 내용**

### 문제

기존 쿼리는 `IS NULL` 이 **ORDER BY 보다 먼저 걸리는 WHERE 조건**이었습니다.

```sql
WHERE organizer = ? AND end_time < now AND expected_running_distance_km IS NULL
ORDER BY end_time DESC, id DESC LIMIT 1
```

즉 "거리 미입력 이벤트들 중 최신 1건"을 반환합니다. 의도한 동작인 "가장 최신 이벤트가 미입력일 때만 반환"과 다릅니다.

재현 시나리오:

| 이벤트 | 종료일 | 거리 |
|---|---|---|
| A | 7/20 | 15.0 (입력됨) |
| B | 7/10 | null |

- 기대: 최신은 A 이고 거리가 입력돼 있으므로 → `items: []`
- 실제: B 가 반환됨 → 이미 지나간 이벤트의 거리 입력 요청이 계속 노출

### 수정

WHERE 에서 NULL 조건을 빼고 최신 종료 이벤트 1건만 가져온 뒤, 그 이벤트의 거리가 null 일 때만 응답에 포함합니다.

```java
// EventRepository
List<Event> findAllByOrganizerAndEndTimeBeforeOrderByEndTimeDescIdDesc(
        String organizer, LocalDateTime now, Pageable pageable);

// EventService
.findAllByOrganizerAndEndTimeBeforeOrderByEndTimeDescIdDesc(
        privateId, EventTemporalStatusResolver.now(), PageRequest.of(0, 1))
.stream()
.filter(event -> event.getExpectedRunningDistanceKm() == null)
```

`LIMIT 1` 은 유지되므로 쿼리 비용은 동일합니다. 기존 `...AndExpectedRunningDistanceKmIsNull...` 메서드는 호출부가 없어져 제거했습니다. DB 스키마 변경은 없고, 응답 스펙(`items`)도 그대로입니다.

## **검증**

TDD 로 진행했습니다. 기존 테스트는 리포지토리를 mock 으로 stub 하고 있어서 이 버그를 잡지 못했습니다 (어떤 쿼리를 던지는지가 검증되지 않음). 먼저 테스트를 추가해 실패를 확인했습니다.

```
EventRenewalServiceTest > 러닝 거리 미입력 이벤트 조회는 내가 주최한 종료 이벤트 중 최신 1개를 반환한다 FAILED
    java.lang.AssertionError at EventRenewalServiceTest.java:289
EventRenewalServiceTest > 가장 최신 종료 이벤트에 러닝 거리가 이미 있으면 빈 목록을 반환한다 FAILED
    org.mockito.exceptions.misusing.UnnecessaryStubbingException
EventRenewalServiceTest > 러닝 거리 미입력 이벤트 조회는 최신 종료 이벤트 1건만 조회한다 FAILED
    org.mockito.exceptions.verification.WantedButNotInvoked at EventRenewalServiceTest.java:323
```

3건 모두 서비스가 여전히 기존 `IS NULL` 쿼리를 호출해서 실패합니다. 구현 후:

| 항목 | 결과 |
|---|---|
| `EventRenewalServiceTest` | tests=19, failures=0, errors=0 |
| `com.guide.run.event.*` 전체 | tests=88, failures=0, errors=0 |
| `./gradlew test` 전체 | 173건 중 170건 통과 |

전체 실행 시 실패하는 3건(`RunApplicationTests.contextLoads`, `UserServiceTest` 2건)은 **이 변경과 무관한 기존 실패**입니다. 로컬 DB 연결이 필요한 `@SpringBootTest` 컨텍스트 로딩 실패이며, 변경분을 stash 하고 동일 커밋에서 실행해도 같은 3건이 실패하는 것을 확인했습니다.

```
Caused by: jakarta.persistence.PersistenceException at AbstractEntityManagerFactoryBean.java:421
    Caused by: java.lang.RuntimeException at DriverDataSource.java:110
```

## **관련 이슈**
Resolves: 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 종료된 이벤트의 러닝 거리 미입력 여부를 보다 정확하게 확인하도록 조회 방식이 개선되었습니다.
  * 최신 종료 이벤트에 예상 러닝 거리가 입력된 경우, 추가 입력 대상에서 제외됩니다.

* **테스트**
  * 최신 이벤트 조회 및 페이지 조건에 대한 검증을 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->